### PR TITLE
Join items.invalidcolornew with interpunct

### DIFF
--- a/packages/dota/src/twitch/commands/stats.ts
+++ b/packages/dota/src/twitch/commands/stats.ts
@@ -55,7 +55,7 @@ export function getPlayerFromArgs({
 
   if (heroKey < 0 || heroKey > 9) {
     throw new CustomError(
-      t('invalidColorNew', { command, colorList: heroColors.join(' '), lng: locale }),
+      t('invalidColorNew', { command, colorList: heroColors.join(' · '), lng: locale }),
     )
   }
 


### PR DESCRIPTION
More readable and matches the argument used previously
