### PR TITLE
Sorted players by team_slot on RealTimeStats

### DIFF
--- a/packages/dota/src/types.ts
+++ b/packages/dota/src/types.ts
@@ -514,6 +514,7 @@ export interface DelayedGames {
       items: number[]
       heroid: number
       accountid: string
+      team_slot: number
     }[]
   }[]
 }

--- a/packages/steam/src/steam.ts
+++ b/packages/steam/src/steam.ts
@@ -139,7 +139,7 @@ function hasSteamData(game?: DelayedGames | null) {
 
 function sortPlayersBySlot(game: DelayedGames) {
   for (const team of game.teams) {
-    team.players = team.players.sort((a, b) => a.team_slot - b.team_slot)
+    team.players.sort((a, b) => a.team_slot - b.team_slot)
   }
 }
 

--- a/packages/steam/src/steam.ts
+++ b/packages/steam/src/steam.ts
@@ -137,6 +137,12 @@ function hasSteamData(game?: DelayedGames | null) {
   return { hasAccountIds, hasPlayers, hasHeroes }
 }
 
+function sortPlayersBySlot(game: DelayedGames) {
+  for (const team of game.teams) {
+    team.players = team.players.sort((a, b) => a.team_slot - b.team_slot)
+  }
+}
+
 class Dota {
   private static instance: Dota
   private cache: Map<number, CacheEntry> = new Map()
@@ -509,6 +515,9 @@ class Dota {
         // needs hero data
         const retryAttempt2 = waitForHeros && !hasHeroes ? new Error() : undefined
         if (operation.retry(retryAttempt2)) return
+
+        // sort players by team_slot
+        sortPlayersBySlot(game)
 
         // 2-minute delay gives "0" match id, so we use the gsi match id instead
         game.match.match_id = match_id

--- a/packages/steam/src/types/index.ts
+++ b/packages/steam/src/types/index.ts
@@ -514,6 +514,7 @@ export interface DelayedGames {
       items: number[]
       heroid: number
       accountid: string
+      team_slot: number
     }[]
   }[]
 }


### PR DESCRIPTION
# Pull Request Title
Sorted players by team_slot on RealTimeStats

## Current Behavior
The player order is wrong for Immortal Ranked Match Making.

## New Behavior
The player order should now be correct. Should not affect any other matches that are not immortal ranked matches.
