### PR TITLE
Fix twitch token timestamp

### DIFF
--- a/packages/shared-utils/src/twitch/getTwitchAPI.ts
+++ b/packages/shared-utils/src/twitch/getTwitchAPI.ts
@@ -34,7 +34,9 @@ export const getTwitchAPI = async (twitchId?: string): Promise<ApiClient> => {
       const tokenData = {
         scope: tokens.scope?.split(' ') ?? [],
         expiresIn: tokens.expires_in ?? 0,
-        obtainmentTimestamp: new Date(tokens.obtainment_timestamp || '')?.getTime(),
+        obtainmentTimestamp: tokens.obtainment_timestamp
+          ? new Date(tokens.obtainment_timestamp).getTime()
+          : Date.now(),
         accessToken,
         refreshToken,
       }


### PR DESCRIPTION
## Summary
- avoid NaN timestamps when creating the Twitch API client

## Testing
- `npx biome check packages/shared-utils/src/twitch/getTwitchAPI.ts` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*