### PR TITLE
Fix include lead moderators in chat moderator checks

### DIFF
--- a/packages/twitch-chat/src/handleChat.ts
+++ b/packages/twitch-chat/src/handleChat.ts
@@ -25,7 +25,9 @@ function extractUserInfo(
   chatterUserId: string,
 ) {
   return {
-    isMod: badges.some((badge) => badge.set_id === 'moderator'),
+    isMod: badges.some(
+      (badge) => badge.set_id === 'moderator' || badge.set_id === 'lead_moderator',
+    ),
     isBroadcaster: broadcasterUserId === chatterUserId,
     isSubscriber: badges.some((badge) => badge.set_id === 'subscriber'),
     userId: chatterUserId,


### PR DESCRIPTION
# Include lead moderators in chat moderator checks

## Summary
- extend chat moderator checks to include lead moderators

## Testing
- manual review