### PR TITLE
chore(dota): refresh dotaconstants commit pins for latest patch data

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -788,7 +788,7 @@
 
     "dota2": ["dota2@github:dotabod/node-dota2#4a1a095", { "dependencies": { "deferred": "^0.7.10", "long": "^4.0.0", "merge": "^1.2.1", "steam": "https://github.com/dotabod/node-steam", "steam-resources": "https://github.com/dotabod/node-steam-resources", "winston": "^3.2.1" } }, "dotabod-node-dota2-4a1a095"],
 
-    "dotaconstants": ["dotaconstants@github:dotabod/dotaconstants#04f7d58", {}, "dotabod-dotaconstants-04f7d58"],
+    "dotaconstants": ["dotaconstants@github:dotabod/dotaconstants#568dbfb", {}, "dotabod-dotaconstants-568dbfb"],
 
     "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3110,7 +3110,7 @@
     },
     "node_modules/dotaconstants": {
       "version": "9.4.1",
-      "resolved": "git+ssh://git@github.com/dotabod/dotaconstants.git#0368452d0a8559419c3d597cf538e61ce1937baa",
+      "resolved": "git+ssh://git@github.com/dotabod/dotaconstants.git#568dbfb7d2e7f0f3958f8190e1d19f98b744a0ef",
       "license": "MIT"
     },
     "node_modules/ee-first": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked GH Issues
- N/A

## Current Behavior
- Dota data consumers (heroes/items/facets/innates/aghs) are pinned via lockfiles to older `dotaconstants` commits.
- `bun.lock` and `package-lock.json` point to different historical commits, which increases risk of stale or inconsistent data depending on install path.

## New Behavior
- Updated `bun.lock` `dotaconstants` pin to `568dbfb`.
- Updated `package-lock.json` resolved SHA to `568dbfb7d2e7f0f3958f8190e1d19f98b744a0ef`.
- This aligns data pulls with the latest `dotabod/dotaconstants` master commit, reducing patch drift risk for hardcoded/static data consumers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a413366e-42f9-4cc6-ab03-80766e7b33c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a413366e-42f9-4cc6-ab03-80766e7b33c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

