### PR TITLE
ci: add low-noise dotaconstants refresh automation

### DIFF
--- a/.github/scripts/update_dotaconstants.py
+++ b/.github/scripts/update_dotaconstants.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OWNER = 'dotabod'
+REPO = 'dotaconstants'
+
+BUN_LOCK_PATH = Path('bun.lock')
+NPM_LOCK_PATH = Path('package-lock.json')
+
+# Only files with direct gameplay / command-facing impact.
+# This keeps automation focused and avoids PR noise from unrelated metadata churn.
+PATCH_RELEVANT_FILES = [
+  'build/heroes.json',
+  'build/items.json',
+  'build/item_ids.json',
+  'build/abilities.json',
+  'build/hero_abilities.json',
+  'build/aghs_desc.json',
+]
+
+
+def write_output(name: str, value: str) -> None:
+  output_path = os.getenv('GITHUB_OUTPUT')
+  if not output_path:
+    return
+  with open(output_path, 'a', encoding='utf-8') as file:
+    file.write(f'{name}={value}\n')
+
+
+def fail(message: str) -> None:
+  print(f'error: {message}', file=sys.stderr)
+  write_output('should_update', 'false')
+  write_output('reason', message)
+  sys.exit(1)
+
+
+def fetch_text(url: str, token: str | None = None) -> str:
+  headers = {'Accept': 'application/vnd.github+json'}
+  if token:
+    headers['Authorization'] = f'Bearer {token}'
+  request = urllib.request.Request(url, headers=headers)
+  try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+      return response.read().decode('utf-8')
+  except urllib.error.HTTPError as error:
+    fail(f'failed to fetch {url}: HTTP {error.code}')
+  except urllib.error.URLError as error:
+    fail(f'failed to fetch {url}: {error.reason}')
+  return ''
+
+
+def fetch_bytes(url: str) -> bytes:
+  request = urllib.request.Request(url)
+  with urllib.request.urlopen(request, timeout=30) as response:
+    return response.read()
+
+
+def extract_bun_sha() -> str:
+  text = BUN_LOCK_PATH.read_text(encoding='utf-8')
+  match = re.search(r'dotaconstants#([0-9a-f]{7,40})', text)
+  if not match:
+    fail('could not locate dotaconstants SHA in bun.lock')
+  return match.group(1)
+
+
+def extract_npm_sha() -> str:
+  text = NPM_LOCK_PATH.read_text(encoding='utf-8')
+  match = re.search(r'dotaconstants\.git#([0-9a-f]{40})', text)
+  if not match:
+    fail('could not locate dotaconstants SHA in package-lock.json')
+  return match.group(1)
+
+
+def get_latest_sha(token: str | None) -> str:
+  url = f'https://api.github.com/repos/{OWNER}/{REPO}/commits/master'
+  payload = fetch_text(url, token)
+  match = re.search(r'"sha"\s*:\s*"([0-9a-f]{40})"', payload)
+  if not match:
+    fail('could not parse latest dotaconstants SHA from GitHub API response')
+  return match.group(1)
+
+
+def get_changed_patch_relevant_files(current_sha: str, latest_sha: str) -> list[str]:
+  changed_files: list[str] = []
+  for file_path in PATCH_RELEVANT_FILES:
+    current_url = f'https://raw.githubusercontent.com/{OWNER}/{REPO}/{current_sha}/{file_path}'
+    latest_url = f'https://raw.githubusercontent.com/{OWNER}/{REPO}/{latest_sha}/{file_path}'
+    try:
+      current_bytes = fetch_bytes(current_url)
+      latest_bytes = fetch_bytes(latest_url)
+    except urllib.error.HTTPError as error:
+      print(
+        f'warning: {file_path} unavailable during comparison ({error.code}); treating as changed',
+      )
+      changed_files.append(file_path)
+      continue
+    except urllib.error.URLError as error:
+      fail(f'failed to compare {file_path}: {error.reason}')
+
+    if current_bytes != latest_bytes:
+      changed_files.append(file_path)
+
+  return changed_files
+
+
+def update_lockfiles(latest_sha: str) -> None:
+  short_sha = latest_sha[:7]
+
+  bun_text = BUN_LOCK_PATH.read_text(encoding='utf-8')
+  bun_pattern = re.compile(
+    r'("dotaconstants": \["dotaconstants@github:dotabod/dotaconstants#)[0-9a-f]{7,40}'
+    r'(", \{\}, "dotabod-dotaconstants-)[0-9a-f]{7,40}("\],)',
+  )
+  bun_text, bun_replacements = bun_pattern.subn(
+    rf'\g<1>{short_sha}\g<2>{short_sha}\g<3>',
+    bun_text,
+    count=1,
+  )
+  if bun_replacements != 1:
+    fail('expected exactly one dotaconstants entry update in bun.lock')
+
+  npm_text = NPM_LOCK_PATH.read_text(encoding='utf-8')
+  npm_pattern = re.compile(
+    r'(git\+ssh://git@github\.com/dotabod/dotaconstants\.git#)[0-9a-f]{40}',
+  )
+  npm_text, npm_replacements = npm_pattern.subn(rf'\g<1>{latest_sha}', npm_text, count=1)
+  if npm_replacements != 1:
+    fail('expected exactly one dotaconstants resolved entry update in package-lock.json')
+
+  BUN_LOCK_PATH.write_text(bun_text, encoding='utf-8')
+  NPM_LOCK_PATH.write_text(npm_text, encoding='utf-8')
+
+
+def main() -> None:
+  token = os.getenv('GITHUB_TOKEN')
+  bun_sha = extract_bun_sha()
+  npm_sha = extract_npm_sha()
+
+  if not npm_sha.startswith(bun_sha):
+    print(
+      f'warning: lockfiles currently disagree (bun={bun_sha}, npm={npm_sha}); using bun as baseline',
+    )
+
+  current_sha = bun_sha
+  latest_sha = get_latest_sha(token)
+
+  print(f'current_sha={current_sha}')
+  print(f'latest_sha={latest_sha}')
+
+  write_output('current_sha', current_sha)
+  write_output('latest_sha', latest_sha)
+
+  if latest_sha.startswith(current_sha):
+    print('dotaconstants is already up to date')
+    write_output('should_update', 'false')
+    write_output('reason', 'already_up_to_date')
+    return
+
+  changed_files = get_changed_patch_relevant_files(current_sha, latest_sha)
+  changed_files_output = ','.join(changed_files) if changed_files else 'none'
+  write_output('changed_files', changed_files_output)
+
+  if not changed_files:
+    print('no patch-relevant files changed; skipping lockfile bump')
+    write_output('should_update', 'false')
+    write_output('reason', 'no_patch_relevant_changes')
+    return
+
+  print(f'patch-relevant updates detected: {changed_files_output}')
+  update_lockfiles(latest_sha)
+  write_output('should_update', 'true')
+  write_output('reason', 'patch_relevant_changes')
+
+
+if __name__ == '__main__':
+  main()

--- a/.github/workflows/dotaconstants-update.yml
+++ b/.github/workflows/dotaconstants-update.yml
@@ -1,0 +1,69 @@
+name: Update dotaconstants (low-noise)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly check to avoid noisy update churn.
+    - cron: '30 6 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dotaconstants-update
+  cancel-in-progress: true
+
+jobs:
+  update-dotaconstants:
+    runs-on: ubuntu-latest
+    env:
+      UPDATE_BRANCH: ci/update-dotaconstants
+      BASE_BRANCH: master
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Detect patch-relevant changes and update lockfiles
+        id: scan
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/update_dotaconstants.py
+
+      - name: Create Pull Request
+        if: steps.scan.outputs.should_update == 'true'
+        uses: peter-evans/create-pull-request@v8.1.0
+        with:
+          title: 'chore(dota): update dotaconstants for patch-relevant changes'
+          body: |
+            Automated dotaconstants refresh.
+
+            This PR is created only when patch-relevant datasets changed in `dotabod/dotaconstants`:
+            - `build/heroes.json`
+            - `build/items.json`
+            - `build/item_ids.json`
+            - `build/abilities.json`
+            - `build/hero_abilities.json`
+            - `build/aghs_desc.json`
+
+            Updated lockfiles:
+            - `bun.lock`
+            - `package-lock.json`
+
+            Comparison:
+            - Previous SHA: `${{ steps.scan.outputs.current_sha }}`
+            - Latest SHA: `${{ steps.scan.outputs.latest_sha }}`
+            - Changed relevant files: `${{ steps.scan.outputs.changed_files }}`
+          base: ${{ env.BASE_BRANCH }}
+          branch: ${{ env.UPDATE_BRANCH }}
+          commit-message: 'chore(dota): refresh dotaconstants lockfile pins'
+          delete-branch: true
+          add-paths: |
+            bun.lock
+            package-lock.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked GH Issues
- N/A

## Current Behavior
- `dotaconstants` lockfile pins are updated manually.
- Upstream `dotaconstants` can move frequently, and not every commit is patch-relevant for bot behavior.

## New Behavior
- Added a scheduled/manual workflow: `.github/workflows/dotaconstants-update.yml`.
- Added `.github/scripts/update_dotaconstants.py` to:
  - compare current pinned SHA vs latest upstream SHA,
  - diff only patch-relevant files:
    - `build/heroes.json`
    - `build/items.json`
    - `build/item_ids.json`
    - `build/abilities.json`
    - `build/hero_abilities.json`
    - `build/aghs_desc.json`
  - update `bun.lock` and `package-lock.json` only when one of those files changed.
- Workflow opens/updates a PR via `peter-evans/create-pull-request` only when patch-relevant changes exist.
- Schedule is weekly (`30 6 * * 1`) to reduce noise, with `workflow_dispatch` for manual runs.

## Notes
- The script gracefully skips updates when upstream changed but none of the tracked gameplay datasets changed.
- This keeps data reasonably fresh without churning PRs for non-impactful `dotaconstants` commits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a413366e-42f9-4cc6-ab03-80766e7b33c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a413366e-42f9-4cc6-ab03-80766e7b33c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

