### PR TITLE
fix: resolve GitHub Actions CI blockers

### DIFF
--- a/packages/dota/src/dota/GSIServer.ts
+++ b/packages/dota/src/dota/GSIServer.ts
@@ -281,7 +281,9 @@ class GSIServer implements GSIServerInterface {
         // Check if the set still exists in case it was cleared/modified elsewhere
         const currentSet = clipsToDeleteQueue.get(accountId)
         if (currentSet) {
-          slugsArray.forEach((slug) => currentSet.delete(slug))
+          slugsArray.forEach((slug) => {
+            currentSet.delete(slug)
+          })
           // If the set becomes empty after deletion, remove the user entry
           if (currentSet.size === 0) {
             clipsToDeleteQueue.delete(accountId)

--- a/packages/dota/src/dota/__tests__/NeutralItemTimer.test.ts
+++ b/packages/dota/src/dota/__tests__/NeutralItemTimer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 
 import { NEUTRAL_ITEM_TIER_TIMES } from '../NeutralItemTimer.js'
 

--- a/packages/dota/src/dota/events/gsi-events/__tests__/event.aegis.test.ts
+++ b/packages/dota/src/dota/events/gsi-events/__tests__/event.aegis.test.ts
@@ -1,5 +1,5 @@
-import { faker } from '@faker-js/faker'
 import { describe, it } from 'bun:test'
+import { faker } from '@faker-js/faker'
 
 import { apiClient } from '../../../../__tests__/utils.js'
 import { DotaEventTypes } from '../../../../types.js'

--- a/packages/dota/src/dota/lib/__tests__/DelayedQueue.integration.test.ts
+++ b/packages/dota/src/dota/lib/__tests__/DelayedQueue.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration test for DelayedQueue without external dependencies
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { DelayedQueue } from '../DelayedQueue.js'
 
 describe('DelayedQueue Integration', () => {

--- a/packages/dota/src/dota/lib/__tests__/DelayedQueue.test.ts
+++ b/packages/dota/src/dota/lib/__tests__/DelayedQueue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { DelayedQueue } from '../DelayedQueue.js'
 
 describe('DelayedQueue', () => {

--- a/packages/dota/src/dota/lib/heroes.ts
+++ b/packages/dota/src/dota/lib/heroes.ts
@@ -85,7 +85,7 @@ export function getHeroByName(name: string, heroIdsInMatch?: (number | undefined
           .trim() === localName,
     )
 
-    if (hasAlias) return true
+    return hasAlias
   })
 
   // then hero name

--- a/packages/dota/src/settings.ts
+++ b/packages/dota/src/settings.ts
@@ -9,7 +9,7 @@ import {
 import type { SubscriptionRow } from './types/subscription.js'
 import { canAccessFeature } from './utils/subscription.js'
 
-export { DBSettings, type SettingKeys, type CommandKeys, type ChatterKeys }
+export { type ChatterKeys, type CommandKeys, DBSettings, type SettingKeys }
 
 export const commands = defaultCommands
 export const defaultSettings = defaultSettingsStructure

--- a/packages/dota/src/twitch/commands/geo.ts
+++ b/packages/dota/src/twitch/commands/geo.ts
@@ -1,14 +1,13 @@
+import { countryCodeEmoji } from 'country-code-emoji'
 import { t } from 'i18next'
-
 import RedisClient from '../../db/RedisClient.js'
 import { getAccountsFromMatch } from '../../dota/lib/getAccountsFromMatch.js'
 import { isSpectator } from '../../dota/lib/isSpectator.js'
 import { DBSettings, ENABLE_SPECTATE_FRIEND_GAME } from '../../settings.js'
 import CustomError from '../../utils/customError.js'
-import { is8500Plus, steamID64toSteamID32, steamID32toSteamID64 } from '../../utils/index.js'
+import { is8500Plus, steamID32toSteamID64, steamID64toSteamID32 } from '../../utils/index.js'
 import { chatClient } from '../chatClient.js'
 import commandHandler, { type MessageType } from '../lib/CommandHandler.js'
-import { countryCodeEmoji } from 'country-code-emoji'
 
 commandHandler.registerCommand('geo', {
   aliases: ['country', 'location'],
@@ -61,7 +60,7 @@ commandHandler.registerCommand('geo', {
 
       const accounts = matchPlayers.map((p) => Number(p.accountid)).filter((id) => id > 0)
 
-      let accountIdToCountry = new Map<number, string>()
+      const accountIdToCountry = new Map<number, string>()
 
       if (accounts.length) {
         const steamids = accounts

--- a/packages/dota/src/twitch/commands/lost.ts
+++ b/packages/dota/src/twitch/commands/lost.ts
@@ -1,12 +1,12 @@
 import { logger } from '@dotabod/shared-utils'
 import { t } from 'i18next'
 import { redisClient } from '../../db/redisInstance.js'
+import { gsiHandlers } from '../../dota/lib/consts.js'
 import { DBSettings } from '../../settings.js'
 import { steamSocket } from '../../steam/ws.js'
 import type { MatchMinimalDetailsResponse } from '../../types.js'
 import { chatClient } from '../chatClient.js'
 import commandHandler, { type MessageType } from '../lib/CommandHandler.js'
-import { gsiHandlers } from '../../dota/lib/consts.js'
 import { resolveMatchRetroactively } from '../lib/resolveMatch.js'
 
 commandHandler.registerCommand('lost', {

--- a/packages/dota/src/twitch/commands/won.ts
+++ b/packages/dota/src/twitch/commands/won.ts
@@ -1,12 +1,12 @@
 import { logger } from '@dotabod/shared-utils'
 import { t } from 'i18next'
 import { redisClient } from '../../db/redisInstance.js'
+import { gsiHandlers } from '../../dota/lib/consts.js'
 import { DBSettings } from '../../settings.js'
 import { steamSocket } from '../../steam/ws.js'
 import type { MatchMinimalDetailsResponse } from '../../types.js'
 import { chatClient } from '../chatClient.js'
 import commandHandler, { type MessageType } from '../lib/CommandHandler.js'
-import { gsiHandlers } from '../../dota/lib/consts.js'
 import { resolveMatchRetroactively } from '../lib/resolveMatch.js'
 
 commandHandler.registerCommand('won', {

--- a/packages/dota/src/twitch/lib/__tests__/closeTwitchBet.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/closeTwitchBet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock, spyOn } from 'bun:test'
+import { beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { getTwitchAPI, logger } from '@dotabod/shared-utils'
 import { DBSettings } from '../../../settings.js'
 import type { SocketClient } from '../../../types.js'

--- a/packages/dota/src/twitch/lib/__tests__/refundTwitchBets.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/refundTwitchBets.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import { getTwitchAPI, logger } from '@dotabod/shared-utils'
 import { refundTwitchBet } from '../refundTwitchBets.js'
 

--- a/packages/profanity-filter/tests/moderation.test.ts
+++ b/packages/profanity-filter/tests/moderation.test.ts
@@ -350,7 +350,7 @@ async function compareLibraries() {
 
   rankedLibraries.forEach((lib, index) => {
     // console.log(
-      // `${index + 1}.   | ${lib.name.padEnd(22)} | ${lib.rate.toFixed(1)}% | ${lib.detected}/${lib.total}`,
+    // `${index + 1}.   | ${lib.name.padEnd(22)} | ${lib.rate.toFixed(1)}% | ${lib.detected}/${lib.total}`,
     // )
   })
 }

--- a/packages/twitch-events/src/utils/rateLimiter.ts
+++ b/packages/twitch-events/src/utils/rateLimiter.ts
@@ -15,13 +15,6 @@ interface TwitchSubscriptionTransport {
   conduit_id?: string
 }
 
-interface TwitchSubscriptionRequest {
-  type: string
-  version: string
-  condition: TwitchSubscriptionCondition
-  transport: TwitchSubscriptionTransport
-}
-
 interface TwitchSubscription {
   id: string
   status: 'enabled' | 'webhook_callback_verification_pending' | string

--- a/packages/twitch-events/src/utils/webhookUtils.ts
+++ b/packages/twitch-events/src/utils/webhookUtils.ts
@@ -39,7 +39,7 @@ export const setupWebhooks = () => {
 
   webhookApp.use(bodyParserErrorHandler() as unknown as ErrorRequestHandler)
 
-  webhookApp.get('/webhook', (req, res) => {
+  webhookApp.get('/webhook', (_req, res) => {
     res.status(200).json({
       status: 'ok',
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked GH Issues

- N/A

## Current Behavior

- The repository CI workflow is red because the Biome step fails on master.
- Failures include import/export ordering drift, two iterable callback lint errors, and a formatting-only mismatch in the profanity filter test suite.

## New Behavior

- Biome-critical files are updated so the `biome ci .` step passes again.
- Import/export ordering now matches Biome expectations in the affected tests and command files.
- The iterable callbacks in `GSIServer` and `heroes` no longer violate current Biome lint rules.
- The remaining formatting mismatch in `packages/profanity-filter/tests/moderation.test.ts` is normalized.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a08cdcd-edc9-400a-9343-bc7466930691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a08cdcd-edc9-400a-9343-bc7466930691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

