### PR TITLE
fix(ci): make dotaconstants auto-update produce a valid lockfile

### DIFF
--- a/.github/scripts/update_dotaconstants.py
+++ b/.github/scripts/update_dotaconstants.py
@@ -104,21 +104,6 @@ def get_changed_patch_relevant_files(current_sha: str, latest_sha: str) -> list[
   return changed_files
 
 
-def update_lockfile(current_sha: str, latest_sha: str) -> None:
-  text = PNPM_LOCK_PATH.read_text(encoding='utf-8')
-  # pnpm lockfile references the git-hosted tarball with the full SHA in
-  # multiple places (specifier line, package key, resolution block). Replace
-  # every occurrence atomically.
-  updated_text = text.replace(current_sha, latest_sha)
-  occurrences = text.count(current_sha)
-  if occurrences == 0:
-    fail('no dotaconstants SHA occurrences found in pnpm-lock.yaml')
-  if updated_text == text:
-    fail('SHA replacement produced no changes')
-  PNPM_LOCK_PATH.write_text(updated_text, encoding='utf-8')
-  print(f'replaced {occurrences} occurrence(s) of {current_sha[:7]} → {latest_sha[:7]}')
-
-
 def main() -> None:
   token = os.getenv('GITHUB_TOKEN')
   current_sha = extract_current_sha()
@@ -146,8 +131,11 @@ def main() -> None:
     write_output('reason', 'no_patch_relevant_changes')
     return
 
+  # This script only DETECTS whether a refresh is warranted and exposes
+  # latest_sha. The workflow performs the actual bump with pnpm (updating both
+  # packages/dota/package.json and pnpm-lock.yaml, with correct tarball
+  # integrity) — a naive SHA string-replace can't compute the new integrity.
   print(f'patch-relevant updates detected: {changed_files_output}')
-  update_lockfile(current_sha, latest_sha)
   write_output('should_update', 'true')
   write_output('reason', 'patch_relevant_changes')
 

--- a/.github/workflows/dotaconstants-update.yml
+++ b/.github/workflows/dotaconstants-update.yml
@@ -31,12 +31,36 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Detect patch-relevant changes and update lockfiles
+      - name: Detect patch-relevant changes
         id: scan
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           python .github/scripts/update_dotaconstants.py
+
+      - name: Setup pnpm
+        if: steps.scan.outputs.should_update == 'true'
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.2.2
+
+      - name: Setup Node
+        if: steps.scan.outputs.should_update == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # Pin to the exact detected SHA (not the floating branch ref) so the bump
+      # is deterministic regardless of pnpm's git-ref cache. This updates both
+      # packages/dota/package.json and pnpm-lock.yaml (correct tarball integrity)
+      # in one shot, keeping the manifest and lockfile in sync.
+      - name: Bump dotaconstants to latest SHA
+        if: steps.scan.outputs.should_update == 'true'
+        run: |
+          pnpm --filter @dotabod/dota update \
+            "dotaconstants@github:dotabod/dotaconstants#${{ steps.scan.outputs.latest_sha }}" \
+            --lockfile-only
 
       - name: Create Pull Request
         if: steps.scan.outputs.should_update == 'true'
@@ -57,7 +81,8 @@ jobs:
             - `build/hero_abilities.json`
             - `build/aghs_desc.json`
 
-            Updated lockfiles:
+            Updated:
+            - `packages/dota/package.json`
             - `pnpm-lock.yaml`
 
             Comparison:
@@ -66,7 +91,8 @@ jobs:
             - Changed relevant files: `${{ steps.scan.outputs.changed_files }}`
           base: ${{ env.BASE_BRANCH }}
           branch: ${{ env.UPDATE_BRANCH }}
-          commit-message: 'chore(dota): refresh dotaconstants lockfile pins'
+          commit-message: 'chore(dota): refresh dotaconstants pin'
           delete-branch: true
           add-paths: |
+            packages/dota/package.json
             pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lefthook": "^1.11.6",
     "ts-morph": "^28.0.0",
     "typescript": "^5.8",
-    "vite-plus": "latest"
+    "vite-plus": "0.1.23"
   },
   "overrides": {
     "vite": "npm:@voidzero-dev/vite-plus-core@latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         specifier: ^5.8
         version: 5.9.3
       vite-plus:
-        specifier: latest
+        specifier: 0.1.23
         version: 0.1.23(@types/node@22.19.19)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   packages/dota:


### PR DESCRIPTION
## Problem

PR #587 (auto dotaconstants update) broke `master` CI's `pnpm install --frozen-lockfile`:

1. **Wrong integrity** — `update_dotaconstants.py` did `text.replace(old_sha, new_sha)` on `pnpm-lock.yaml`. The tarball `integrity:` hash isn't the git SHA, so the replace left the *old* hash on the *new* tarball → `ERR_PNPM_TARBALL_INTEGRITY`.
2. **Manifest/lockfile divergence** — it bumped only the lockfile while `packages/dota/package.json` stayed SHA-pinned → `ERR_PNPM_OUTDATED_LOCKFILE`.

(master was already unbroken by reverting #587 in `c2ad196c`.)

### Root landmine
Root `package.json` had `"vite-plus": "latest"`. *Any* pnpm resolution re-resolves it (0.1.23 → 0.1.24), silently changing oxlint and producing lint churn — this is what made the auto-update unsafe and is a non-reproducible-build hazard for every contributor.

## Fix

- **Pin `vite-plus` to `0.1.23`** (the version green master resolves) for reproducible installs.
- **`update_dotaconstants.py` → pure patch-relevance detector** (broken string-replace removed).
- **Workflow bumps via pnpm**: `pnpm --filter @dotabod/dota update dotaconstants@github:dotabod/dotaconstants#<latest_sha> --lockfile-only`. Uses the detected exact SHA → deterministic (no reliance on pnpm's git-ref cache, which ignores branch HEAD moves), correct integrity, and updates **both** `packages/dota/package.json` and `pnpm-lock.yaml` in sync (both committed).

dotaconstants itself stays at the current `70fffb9`; the next scheduled run will bump it correctly.

## Verification
- `pnpm install --frozen-lockfile` → exit 0
- `vp check` → 0 lint/format/type errors (matches green master)
- explicit-SHA `pnpm update` verified surgical: only the dotaconstants entry changes, correct `sha512` integrity, zero `vite-plus` drift once pinned