### PR TITLE
fix(twitch-chat): watchdog to self-heal wedged EventSub init

### DIFF
--- a/packages/twitch-chat/src/conduitSetup.ts
+++ b/packages/twitch-chat/src/conduitSetup.ts
@@ -63,17 +63,35 @@ eventsSocket.on('disconnect', (reason) => {
   logger.info('[TWITCHCHAT] Disconnected from twitch-events service', { reason })
 })
 
+// Watchdog: the connect-driven self-heal above can miss a recovery when the link
+// to twitch-events flaps mid-init. If the socket drops while getConduitId() is
+// waiting, eventSubInitInFlight stays true; the reconnect's
+// ensureEventSubInitialized() then bails on that guard, and by the time the
+// stale attempt times out and clears the guard there's no 'connect' event left
+// to retrigger init — EventSub stays dead until a manual restart (seen
+// 2026-06-09). This interval reconciles that state unconditionally: link up but
+// EventSub down with no init in flight means we wedged, so re-init.
+const EVENTSUB_WATCHDOG_MS = 30_000
+setInterval(() => {
+  if (eventsSocket.connected && !isEventsubConnected() && !eventSubInitInFlight) {
+    logger.warn('[TWITCHCHAT] Watchdog: twitch-events link up but EventSub down, re-initializing')
+    void ensureEventSubInitialized('watchdog')
+  }
+}, EVENTSUB_WATCHDOG_MS)
+
 // Function to fetch conduit ID via socket.io
 async function getConduitId(forceRefresh = false): Promise<string> {
   return new Promise((resolve, reject) => {
-    // Set timeout for the request
-    const timeout = setTimeout(() => {
-      reject(new Error('Timeout waiting for conduit data'))
-    }, 15000)
-
-    // Set up one-time listeners for the response
-    eventsSocket.once('conduitData', (data) => {
+    // Remove both listeners on any settle so repeated watchdog-driven retries
+    // (while twitch-events is down) don't leak handlers / trip MaxListeners.
+    const cleanup = () => {
       clearTimeout(timeout)
+      eventsSocket.off('conduitData', onData)
+      eventsSocket.off('conduitError', onError)
+    }
+
+    const onData = (data: { conduitId?: string }) => {
+      cleanup()
       if (data?.conduitId) {
         logger.info('[TWITCHCHAT] Received conduit ID', {
           conduitId: `${data.conduitId.substring(0, 8)}...`,
@@ -82,13 +100,21 @@ async function getConduitId(forceRefresh = false): Promise<string> {
       } else {
         reject(new Error('Invalid conduit data received'))
       }
-    })
+    }
 
-    eventsSocket.once('conduitError', (error) => {
-      clearTimeout(timeout)
+    const onError = (error: { error?: string }) => {
+      cleanup()
       logger.error('[TWITCHCHAT] Error getting conduit ID', { error })
       reject(new Error(error.error || 'Unknown error getting conduit ID'))
-    })
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timeout waiting for conduit data'))
+    }, 15000)
+
+    eventsSocket.on('conduitData', onData)
+    eventsSocket.on('conduitError', onError)
 
     // Request the conduit data
     logger.info('[TWITCHCHAT] Requesting conduit data', { forceRefresh })


### PR DESCRIPTION
## Problem

On 2026-06-09 a host-wide restart brought `twitch-chat` (`zwgkg48`) up before `twitch-events` was ready to serve socket.io (it spends ~1.5min loading 131k subscriptions). twitch-chat's conduit fetch flapped (`xhr poll error` / `transport close`), then **wedged at 07:52:23 and went silent for ~24min** while a background timer kept pushing `eventsub disconnected` to Kuma — lighting up the "Twitch EventSub" monitor. EventSub stayed dead until a manual `docker restart zwgkg48`.

## Root cause

A race in `conduitSetup.ts` defeats the existing `connect`-driven self-heal:

1. Socket connects → `ensureEventSubInitialized` sets `eventSubInitInFlight = true`, starts `getConduitId()` (15s timer).
2. Socket drops mid-wait (`transport close`) — does **not** reject the pending promise, so the guard stays `true`.
3. Socket reconnects → `connect` fires → `ensureEventSubInitialized` hits `if (eventSubInitInFlight) return` and **bails**.
4. The original `getConduitId` finally times out and clears the guard — but the `connect` event already passed. Nothing retriggers init → permanent zombie.

The guard meant to prevent duplicate inits swallows the one retry that would have recovered it.

## Fix

- **30s watchdog** that reconciles unconditionally (immune to event ordering): if `eventsSocket.connected && !isEventsubConnected() && !eventSubInitInFlight`, re-init. Would have recovered this within 30s.
- Harden `getConduitId` to `off()` its `conduitData`/`conduitError` listeners on settle, so repeated watchdog-driven retries (while twitch-events is down) don't leak handlers / trip MaxListeners.

## Notes

- The live outage is already resolved via manual restart; this prevents the manual step next time. Takes effect after build + deploy of `zwgkg48`.
- This is a startup-race variant of the recurring EventSub zombie (prior silence-path fix was `dc92bbdd`).

## Test

`vp check` + full suite pass (915 passed). Typecheck clean.