### PR TITLE
feat(dota): registry-driven feature announcements

### DIFF
--- a/packages/dota/locales/en/translation.json
+++ b/packages/dota/locales/en/translation.json
@@ -114,6 +114,8 @@
   },
   "cosmetics": {
     "captured": "{{- heroName}} set captured! {{count}} cosmetics → {{- url}}",
+    "captured_one": "{{- heroName}} set captured! {{count}} cosmetic → {{- url}}",
+    "captured_other": "{{- heroName}} set captured! {{count}} cosmetics → {{- url}}",
     "empty": "{{- heroName}} has no cosmetics equipped",
     "list": "{{- heroName}} has {{count}} equipped cosmetics → {{- url}}",
     "list_one": "",

--- a/packages/dota/locales/en/translation.json
+++ b/packages/dota/locales/en/translation.json
@@ -113,10 +113,18 @@
     "overlay_other": "{{count}} streamers using the overlay"
   },
   "cosmetics": {
+    "captured": "{{- heroName}} set captured! {{count}} cosmetics → {{- url}}",
     "empty": "{{- heroName}} has no cosmetics equipped",
     "list": "{{- heroName}} has {{count}} equipped cosmetics → {{- url}}",
     "list_one": "",
     "list_other": ""
+  },
+  "newFeatures": {
+    "announce": {
+      "cosmetics": "🆕 New dotabod feature — your hero's cosmetic set now posts in chat when you pick (or type !set). Manage or opt out of new features → {{- url}}"
+    },
+    "cosmetics": "cosmetic set announcements",
+    "notice": "🆕 {{- feature}} just turned on automatically — Dotabod enables new features by default. Don't want new stuff on by default? Opt out anytime → {{- url}}"
   },
   "countryPlayerList": "Playing with players from {{- countries}}",
   "currentSong": "Now playing: {{artist}} - {{title}}{{album}} {{url}}",

--- a/packages/dota/locales/en/translation.json
+++ b/packages/dota/locales/en/translation.json
@@ -122,9 +122,7 @@
   "newFeatures": {
     "announce": {
       "cosmetics": "🆕 New dotabod feature — your hero's cosmetic set now posts in chat when you pick (or type !set). Manage or opt out of new features → {{- url}}"
-    },
-    "cosmetics": "cosmetic set announcements",
-    "notice": "🆕 {{- feature}} just turned on automatically — Dotabod enables new features by default. Don't want new stuff on by default? Opt out anytime → {{- url}}"
+    }
   },
   "countryPlayerList": "Playing with players from {{- countries}}",
   "currentSong": "Now playing: {{artist}} - {{title}}{{album}} {{url}}",

--- a/packages/dota/src/dota/events/gsi-events/__tests__/hero.id.test.ts
+++ b/packages/dota/src/dota/events/gsi-events/__tests__/hero.id.test.ts
@@ -1,0 +1,176 @@
+// The hero:id handler snapshots the played hero's cosmetics to the DB on every pick/swap,
+// then announces the captured set in chat each match. Whether it announces follows the
+// new-feature gate: an explicit cosmeticsAnnounce wins, else the autoOptInNewFeatures master
+// (default on). The one-time "this feature is new" notice lives elsewhere now
+// (announceFeatures.ts), so this test only covers the per-match set announce.
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { buildSharedUtilsMock, initTestI18n } from '../../../../__tests__/sharedMocks'
+
+const loggerMock = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+}
+// captureCosmetics is mocked below, so nothing in this path actually hits supabase.
+const supabaseMock = {
+  from: () => ({ upsert: async () => ({ data: null, error: null }) }),
+}
+vi.doMock('@dotabod/shared-utils', () =>
+  buildSharedUtilsMock({ supabase: supabaseMock, logger: loggerMock }),
+)
+
+// In-memory Redis so the per-match announce dedupe is exercised for real.
+const redisStore: Record<string, string> = {}
+vi.doMock('../../../../db/RedisClient', () => ({
+  default: {
+    getInstance: () => ({
+      client: {
+        get: async (key: string) => redisStore[key] ?? null,
+        set: async (key: string, val: string) => {
+          redisStore[key] = val
+          return 'OK'
+        },
+      },
+    }),
+  },
+}))
+
+// Control the resolved loadout returned by the (real, elsewhere-tested) capture.
+let capturedItems: unknown[] = []
+const captureMock = vi.fn(async () => capturedItems)
+vi.doMock('../../../lib/captureCosmetics', () => ({ captureCosmetics: captureMock }))
+
+// Capture say() calls instead of hitting the real chat/delay pipeline.
+const sayMock = vi.fn()
+vi.doMock('../../../say', () => ({ say: sayMock }))
+
+// Capture the registered handler instead of wiring the global event emitter.
+let registeredHandler: ((dotaClient: any, heroId: number) => Promise<void> | void) | undefined
+vi.doMock('../../EventHandler', () => ({
+  default: {
+    registerEvent: (_name: string, opts: { handler: typeof registeredHandler }) => {
+      registeredHandler = opts.handler
+    },
+  },
+}))
+
+await initTestI18n()
+await import('../hero.id')
+
+const TOKEN = 'user-token-1'
+const INVOKER_ID = 74
+type Setting = { key: string; value: unknown }
+
+function makeDotaClient(
+  overrides: { stream_online?: boolean; matchid?: string; settings?: Setting[] } = {},
+): { client: any } {
+  const { stream_online = true, matchid = '777', settings = [] } = overrides
+  return {
+    client: {
+      name: 'streamer',
+      token: TOKEN,
+      locale: 'en',
+      stream_online,
+      subscription: undefined,
+      settings,
+      gsi: {
+        player: { activity: 'playing' },
+        map: { matchid },
+        hero: { id: INVOKER_ID },
+      },
+    },
+  }
+}
+
+const messages = () => sayMock.mock.calls.map((c) => String(c[1]))
+
+describe('hero:id — cosmetic set announce', () => {
+  beforeEach(() => {
+    captureMock.mockClear()
+    sayMock.mockReset()
+    for (const k of Object.keys(redisStore)) delete redisStore[k]
+    capturedItems = [{ defindex: 1 }, { defindex: 2 }, { defindex: 3 }, { defindex: 4 }]
+  })
+
+  it('is registered for the hero:id event', () => {
+    expect(registeredHandler).toBeDefined()
+  })
+
+  it('announces the captured set (hero + count + link) by default while live', async () => {
+    await registeredHandler!(makeDotaClient(), INVOKER_ID)
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(sayMock).toHaveBeenCalledTimes(1)
+    const [cosmetics] = messages()
+    expect(cosmetics).toContain('Invoker set captured!')
+    expect(cosmetics).toContain('4 cosmetics')
+    expect(cosmetics).toContain('dotabod.com/streamer/set')
+    expect(redisStore[`${TOKEN}:cosmeticsAnnounced`]).toBe(`777:${INVOKER_ID}`)
+  })
+
+  it('does not re-announce for the same match + hero (reconnect safe)', async () => {
+    await registeredHandler!(makeDotaClient(), INVOKER_ID)
+    sayMock.mockClear()
+    await registeredHandler!(makeDotaClient(), INVOKER_ID)
+
+    expect(captureMock).toHaveBeenCalledTimes(2) // capture always runs
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('announces again in a new match', async () => {
+    await registeredHandler!(makeDotaClient({ matchid: '777' }), INVOKER_ID)
+    await registeredHandler!(makeDotaClient({ matchid: '888' }), INVOKER_ID)
+
+    expect(sayMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stays silent when the master toggle is off and the feature is untouched', async () => {
+    await registeredHandler!(
+      makeDotaClient({ settings: [{ key: 'autoOptInNewFeatures', value: false }] }),
+      INVOKER_ID,
+    )
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('announces when explicitly enabled even with the master toggle off', async () => {
+    await registeredHandler!(
+      makeDotaClient({
+        settings: [
+          { key: 'autoOptInNewFeatures', value: false },
+          { key: 'cosmeticsAnnounce', value: true },
+        ],
+      }),
+      INVOKER_ID,
+    )
+
+    expect(messages().some((m) => m.includes('Invoker set captured!'))).toBe(true)
+  })
+
+  it('stays silent when explicitly disabled even with the master toggle on', async () => {
+    await registeredHandler!(
+      makeDotaClient({ settings: [{ key: 'cosmeticsAnnounce', value: false }] }),
+      INVOKER_ID,
+    )
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('captures but stays silent while offline', async () => {
+    await registeredHandler!(makeDotaClient({ stream_online: false }), INVOKER_ID)
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('captures but stays silent when the hero has no resolved cosmetics', async () => {
+    capturedItems = []
+    await registeredHandler!(makeDotaClient(), INVOKER_ID)
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dota/src/dota/events/gsi-events/hero.id.ts
+++ b/packages/dota/src/dota/events/gsi-events/hero.id.ts
@@ -1,7 +1,7 @@
 import { t } from 'i18next'
 
 import { redisClient } from '../../../db/redisInstance'
-import { DBSettings, getValueOrDefault } from '../../../settings'
+import { isFeatureEnabled } from '../../lib/announceFeatures'
 import { captureCosmetics } from '../../lib/captureCosmetics'
 import { getHeroNameOrColor } from '../../lib/heroes'
 import { isPlayingMatch } from '../../lib/isPlayingMatch'
@@ -17,30 +17,19 @@ eventHandler.registerEvent('hero:id', {
     if (!heroId || heroId <= 0) return
     if (!isPlayingMatch(dotaClient.client.gsi)) return
 
-    // Always snapshot the loadout to the DB, online or not.
+    // Snapshot the loadout on every pick/swap. (This handler only runs while live —
+    // EventHandler gates events on stream_online — so capture is effectively live-only.)
     const items = await captureCosmetics(dotaClient.client)
 
     const client = dotaClient.client
-    // Only announce while live, and only when we actually captured something
-    // (a hero with just base parts resolves to no items).
+    // Only announce when we actually captured something (a hero with just base parts
+    // resolves to no items). The stream_online check is belt-and-suspenders.
     if (!client.stream_online) return
     if (!items.length) return
 
-    // Cosmetic-set announcements are a "new feature": an explicit per-feature
-    // choice always wins; otherwise the streamer's autoOptInNewFeatures master
-    // toggle decides the default (on). cosmeticsAnnounce is null until the
-    // streamer explicitly flips it.
-    const perFeature = getValueOrDefault(
-      DBSettings.cosmeticsAnnounce,
-      client.settings,
-      client.subscription,
-    ) as boolean | null
-    const autoOptIn = getValueOrDefault(
-      DBSettings.autoOptInNewFeatures,
-      client.settings,
-      client.subscription,
-    ) as boolean
-    if ((perFeature ?? autoOptIn) !== true) return
+    // Cosmetic-set announcements are a "new feature": an explicit per-feature choice
+    // wins, else the autoOptInNewFeatures master decides. Shared with the announcer.
+    if (!isFeatureEnabled(client, 'cosmeticsAnnounce')) return
 
     // Announce at most once per match+hero. hero:id can re-fire on a GSI
     // reconnect; storing+comparing the stamp is self-correcting across matches

--- a/packages/dota/src/dota/events/gsi-events/hero.id.ts
+++ b/packages/dota/src/dota/events/gsi-events/hero.id.ts
@@ -1,16 +1,65 @@
+import { t } from 'i18next'
+
+import { redisClient } from '../../../db/redisInstance'
+import { DBSettings, getValueOrDefault } from '../../../settings'
 import { captureCosmetics } from '../../lib/captureCosmetics'
+import { getHeroNameOrColor } from '../../lib/heroes'
 import { isPlayingMatch } from '../../lib/isPlayingMatch'
+import { say } from '../../say'
 import eventHandler from '../EventHandler'
 
 // Fires once whenever GSI reports a new hero id (pick or mid-game swap, since
 // events only emit on change). We snapshot the equipped cosmetics automatically
 // here — no need for chat to run !set — provided wearables are already present
-// (captureCosmetics no-ops otherwise).
+// (captureCosmetics no-ops otherwise), then announce the captured set in chat.
 eventHandler.registerEvent('hero:id', {
   handler: async (dotaClient, heroId: number) => {
     if (!heroId || heroId <= 0) return
     if (!isPlayingMatch(dotaClient.client.gsi)) return
 
-    await captureCosmetics(dotaClient.client)
+    // Always snapshot the loadout to the DB, online or not.
+    const items = await captureCosmetics(dotaClient.client)
+
+    const client = dotaClient.client
+    // Only announce while live, and only when we actually captured something
+    // (a hero with just base parts resolves to no items).
+    if (!client.stream_online) return
+    if (!items.length) return
+
+    // Cosmetic-set announcements are a "new feature": an explicit per-feature
+    // choice always wins; otherwise the streamer's autoOptInNewFeatures master
+    // toggle decides the default (on). cosmeticsAnnounce is null until the
+    // streamer explicitly flips it.
+    const perFeature = getValueOrDefault(
+      DBSettings.cosmeticsAnnounce,
+      client.settings,
+      client.subscription,
+    ) as boolean | null
+    const autoOptIn = getValueOrDefault(
+      DBSettings.autoOptInNewFeatures,
+      client.settings,
+      client.subscription,
+    ) as boolean
+    if ((perFeature ?? autoOptIn) !== true) return
+
+    // Announce at most once per match+hero. hero:id can re-fire on a GSI
+    // reconnect; storing+comparing the stamp is self-correcting across matches
+    // (a new matchid or hero swap re-announces), mirroring emitStreamersInMatch.
+    const { token, name, locale } = client
+    const matchId = client.gsi?.map?.matchid
+    const announcedKey = `${token}:cosmeticsAnnounced`
+    const stamp = `${matchId}:${heroId}`
+    if ((await redisClient.client.get(announcedKey)) === stamp) return
+    await redisClient.client.set(announcedKey, stamp)
+
+    say(
+      client,
+      t('cosmetics.captured', {
+        heroName: getHeroNameOrColor(heroId),
+        count: items.length,
+        url: `dotabod.com/${name}/set`,
+        lng: locale,
+      }),
+    )
   },
 })

--- a/packages/dota/src/dota/events/gsiEventLoader.ts
+++ b/packages/dota/src/dota/events/gsiEventLoader.ts
@@ -17,3 +17,7 @@ import './gsi-events/player.deaths'
 import './gsi-events/player.kill_list'
 import './gsi-events/player.killstreak'
 import './gsi-events/saveHeroesForMatchId'
+import { registerFeatureAnnouncers } from '../lib/announceFeatures'
+
+// Registry-driven "this feature is new" chat announcements (hooks its own GSI listeners).
+registerFeatureAnnouncers()

--- a/packages/dota/src/dota/lib/__tests__/announceFeatures.test.ts
+++ b/packages/dota/src/dota/lib/__tests__/announceFeatures.test.ts
@@ -80,13 +80,15 @@ function makeDotaClient(opts: {
   matchid?: string
   settings?: Setting[]
   playing?: boolean
+  stream_online?: boolean
 }): any {
-  const { token, matchid = 'm1', settings = [], playing = true } = opts
+  const { token, matchid = 'm1', settings = [], playing = true, stream_online = true } = opts
   return {
     client: {
       name: 'streamer',
       token,
       locale: 'en',
+      stream_online,
       subscription: undefined,
       settings,
       gsi: {
@@ -210,6 +212,17 @@ describe('feature announcer', () => {
     )
 
     expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing (and persists no flag) when the stream is offline', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, stream_online: false }),
+      'hero:id',
+      INVOKER_ID,
+    )
+    expect(sayMock).not.toHaveBeenCalled()
+    expect(settingsInserted.size).toBe(0)
   })
 
   it('does not announce or cache on a transient upsert error, and retries next trigger', async () => {

--- a/packages/dota/src/dota/lib/__tests__/announceFeatures.test.ts
+++ b/packages/dota/src/dota/lib/__tests__/announceFeatures.test.ts
@@ -1,0 +1,224 @@
+// The feature announcer fires a "this feature is new" chat message + dashboard notification at
+// a relevant GSI moment, once per streamer, gated by the master/per-feature toggles and capped
+// at one feature per match. Drives the real getValueOrDefault + isPlayingMatch; mocks supabase
+// (durable flag + notification), redis (per-match guard), say, and EventHandler. Each test uses
+// a fresh token so the module-level once-ever cache doesn't leak across cases.
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { buildSharedUtilsMock, initTestI18n } from '../../../__tests__/sharedMocks'
+
+const loggerMock = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+}
+
+// Durable settings flag (ON CONFLICT DO NOTHING → only first insert returns a row) +
+// notifications insert.
+const settingsInserted = new Set<string>()
+const notificationInserts: Array<Record<string, unknown>> = []
+const supabaseMock = {
+  from: (table: string) => ({
+    upsert: (values: { userId: string; key: string }) => ({
+      select: () => {
+        const k = `${values.userId}:${values.key}`
+        const firstTime = !settingsInserted.has(k)
+        settingsInserted.add(k)
+        return Promise.resolve({ data: firstTime ? [{ key: values.key }] : [], error: null })
+      },
+    }),
+    insert: (row: Record<string, unknown>) => {
+      if (table === 'notifications') notificationInserts.push(row)
+      return Promise.resolve({ error: null })
+    },
+  }),
+}
+vi.doMock('@dotabod/shared-utils', () =>
+  buildSharedUtilsMock({ supabase: supabaseMock, logger: loggerMock }),
+)
+
+const redisStore: Record<string, string> = {}
+vi.doMock('../../../db/RedisClient', () => ({
+  default: {
+    getInstance: () => ({
+      client: {
+        get: async (key: string) => redisStore[key] ?? null,
+        set: async (key: string, val: string) => {
+          redisStore[key] = val
+          return 'OK'
+        },
+      },
+    }),
+  },
+}))
+
+const sayMock = vi.fn()
+vi.doMock('../../say', () => ({ say: sayMock }))
+
+const registeredTriggers: string[] = []
+vi.doMock('../../events/EventHandler', () => ({
+  default: { registerEvent: (name: string) => registeredTriggers.push(name) },
+}))
+
+await initTestI18n()
+const { dispatchFeatureAnnouncements, registerFeatureAnnouncers, isFeatureEnabled } =
+  await import('../announceFeatures')
+
+const INVOKER_ID = 74
+type Setting = { key: string; value: unknown }
+let tokenCounter = 0
+const freshToken = () => `user-${(tokenCounter += 1)}`
+
+function makeDotaClient(opts: {
+  token: string
+  matchid?: string
+  settings?: Setting[]
+  playing?: boolean
+}): any {
+  const { token, matchid = 'm1', settings = [], playing = true } = opts
+  return {
+    client: {
+      name: 'streamer',
+      token,
+      locale: 'en',
+      subscription: undefined,
+      settings,
+      gsi: {
+        player: playing ? { activity: 'playing' } : {},
+        map: { matchid },
+        hero: { id: INVOKER_ID },
+      },
+    },
+  }
+}
+
+const messages = () => sayMock.mock.calls.map((c) => String(c[1]))
+
+describe('feature announcer', () => {
+  beforeEach(() => {
+    sayMock.mockReset()
+    notificationInserts.length = 0
+    settingsInserted.clear()
+    registeredTriggers.length = 0
+    for (const k of Object.keys(redisStore)) delete redisStore[k]
+  })
+
+  it('registers a listener for each distinct trigger', () => {
+    registerFeatureAnnouncers()
+    expect(registeredTriggers).toContain('hero:id')
+  })
+
+  it('announces a new feature in chat + dashboard by default (master on), once', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(makeDotaClient({ token }), 'hero:id', INVOKER_ID)
+
+    expect(sayMock).toHaveBeenCalledTimes(1)
+    expect(messages()[0]).toContain('dotabod.com/dashboard/whats-new')
+    expect(settingsInserted.has(`${token}:featureAnnounced:cosmetics`)).toBe(true)
+    expect(notificationInserts).toHaveLength(1)
+    expect(notificationInserts[0]).toMatchObject({ userId: token, type: 'NEW_FEATURE' })
+    expect(redisStore[`${token}:featureAnnouncedMatch`]).toBe('m1')
+  })
+
+  it('announces a feature at most once ever (across matches)', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, matchid: 'm1' }),
+      'hero:id',
+      INVOKER_ID,
+    )
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, matchid: 'm2' }),
+      'hero:id',
+      INVOKER_ID,
+    )
+
+    expect(sayMock).toHaveBeenCalledTimes(1)
+    expect(notificationInserts).toHaveLength(1)
+  })
+
+  it('does not announce twice in the same match', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, matchid: 'm1' }),
+      'hero:id',
+      INVOKER_ID,
+    )
+    sayMock.mockClear()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, matchid: 'm1' }),
+      'hero:id',
+      INVOKER_ID,
+    )
+
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when the master toggle is off and the feature is untouched', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, settings: [{ key: 'autoOptInNewFeatures', value: false }] }),
+      'hero:id',
+      INVOKER_ID,
+    )
+
+    expect(sayMock).not.toHaveBeenCalled()
+    expect(notificationInserts).toHaveLength(0)
+  })
+
+  it('announces when the per-feature toggle is explicitly on, even with master off', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({
+        token,
+        settings: [
+          { key: 'autoOptInNewFeatures', value: false },
+          { key: 'cosmeticsAnnounce', value: true },
+        ],
+      }),
+      'hero:id',
+      INVOKER_ID,
+    )
+
+    expect(sayMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays silent when the per-feature toggle is explicitly off, even with master on', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, settings: [{ key: 'cosmeticsAnnounce', value: false }] }),
+      'hero:id',
+      INVOKER_ID,
+    )
+
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when not in a playing match', async () => {
+    const token = freshToken()
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, playing: false }),
+      'hero:id',
+      INVOKER_ID,
+    )
+
+    expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('isFeatureEnabled: untouched follows master, explicit choice wins', () => {
+    const c = (settings: Setting[]) => ({ settings, subscription: undefined }) as any
+    expect(isFeatureEnabled(c([]), 'cosmeticsAnnounce')).toBe(true)
+    expect(
+      isFeatureEnabled(c([{ key: 'autoOptInNewFeatures', value: false }]), 'cosmeticsAnnounce'),
+    ).toBe(false)
+    expect(
+      isFeatureEnabled(
+        c([
+          { key: 'autoOptInNewFeatures', value: false },
+          { key: 'cosmeticsAnnounce', value: true },
+        ]),
+        'cosmeticsAnnounce',
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/dota/src/dota/lib/__tests__/announceFeatures.test.ts
+++ b/packages/dota/src/dota/lib/__tests__/announceFeatures.test.ts
@@ -17,10 +17,16 @@ const loggerMock = {
 // notifications insert.
 const settingsInserted = new Set<string>()
 const notificationInserts: Array<Record<string, unknown>> = []
+let nextUpsertError: unknown = null
 const supabaseMock = {
   from: (table: string) => ({
     upsert: (values: { userId: string; key: string }) => ({
       select: () => {
+        if (nextUpsertError) {
+          const error = nextUpsertError
+          nextUpsertError = null
+          return Promise.resolve({ data: null, error })
+        }
         const k = `${values.userId}:${values.key}`
         const firstTime = !settingsInserted.has(k)
         settingsInserted.add(k)
@@ -100,6 +106,7 @@ describe('feature announcer', () => {
     notificationInserts.length = 0
     settingsInserted.clear()
     registeredTriggers.length = 0
+    nextUpsertError = null
     for (const k of Object.keys(redisStore)) delete redisStore[k]
   })
 
@@ -203,6 +210,26 @@ describe('feature announcer', () => {
     )
 
     expect(sayMock).not.toHaveBeenCalled()
+  })
+
+  it('does not announce or cache on a transient upsert error, and retries next trigger', async () => {
+    const token = freshToken()
+    nextUpsertError = { message: 'db down' }
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, matchid: 'm1' }),
+      'hero:id',
+      INVOKER_ID,
+    )
+    expect(sayMock).not.toHaveBeenCalled()
+    expect(notificationInserts).toHaveLength(0)
+
+    // Error cleared; the next trigger succeeds (the in-memory cache must NOT block it).
+    await dispatchFeatureAnnouncements(
+      makeDotaClient({ token, matchid: 'm2' }),
+      'hero:id',
+      INVOKER_ID,
+    )
+    expect(sayMock).toHaveBeenCalledTimes(1)
   })
 
   it('isFeatureEnabled: untouched follows master, explicit choice wins', () => {

--- a/packages/dota/src/dota/lib/announceFeatures.ts
+++ b/packages/dota/src/dota/lib/announceFeatures.ts
@@ -68,9 +68,15 @@ async function announceFeatureOnce(
     )
     .select('key')
 
-  // Either it's now recorded (first time) or it was already recorded — never look again.
+  // A transient write error: don't cache or claim it — allow a retry on the next trigger
+  // (otherwise the in-memory cache would block this streamer until the process restarts).
+  if (error) {
+    logger.error('[feature-announce] settings flag upsert failed', { id: feature.id, error })
+    return false
+  }
+  // Recorded now (first time) or already recorded earlier — never look again.
   markHandled(cacheKey)
-  if (error || !data?.length) return false // already announced ever, or write failed
+  if (!data?.length) return false // already announced ever
 
   const { error: notifyError } = await supabase
     .from('notifications')

--- a/packages/dota/src/dota/lib/announceFeatures.ts
+++ b/packages/dota/src/dota/lib/announceFeatures.ts
@@ -1,0 +1,125 @@
+import { logger, supabase } from '@dotabod/shared-utils'
+import { t } from 'i18next'
+
+import { redisClient } from '../../db/redisInstance'
+import { DBSettings, getValueOrDefault } from '../../settings'
+import type { SocketClient } from '../../types'
+import eventHandler from '../events/EventHandler'
+import type { GSIHandlerType } from '../GSIHandlerTypes'
+import { say } from '../say'
+import { type FeatureAnnouncement, FEATURE_ANNOUNCEMENTS } from './featureAnnouncements'
+import { isPlayingMatch } from './isPlayingMatch'
+
+const WHATS_NEW_URL = 'dotabod.com/dashboard/whats-new'
+
+// Per-process cache of (token, featureId) pairs we've already handled, so the GSI trigger
+// path doesn't re-hit Postgres every match once a streamer has seen a feature (cf. the
+// BoundedSet in setupSignals.ts). Bounded so long uptimes can't grow it unboundedly.
+const CACHE_MAX = 10_000
+const handledCache = new Set<string>()
+function markHandled(key: string) {
+  if (handledCache.size >= CACHE_MAX) {
+    const oldest = handledCache.values().next().value
+    if (oldest !== undefined) handledCache.delete(oldest)
+  }
+  handledCache.add(key)
+}
+
+// A "new feature" is on when its explicit per-feature toggle is set; otherwise it follows the
+// autoOptInNewFeatures master (default on). Mirrors hero.id.ts's cosmetics gate.
+export function isFeatureEnabled(
+  client: SocketClient,
+  gateSettingKey?: FeatureAnnouncement['gateSettingKey'],
+): boolean {
+  const master = getValueOrDefault(
+    DBSettings.autoOptInNewFeatures,
+    client.settings,
+    client.subscription,
+  ) as boolean
+  if (!gateSettingKey) return master === true
+  const perFeature = getValueOrDefault(gateSettingKey, client.settings, client.subscription) as
+    | boolean
+    | null
+  return (perFeature ?? master) === true
+}
+
+// Announce a single feature to a streamer at most once ever — durable (Postgres flag, survives
+// Redis loss) and race-free via ON CONFLICT DO NOTHING + .select() (only the first insert
+// returns a row). Returns true only when it actually announced. Also drops a NEW_FEATURE
+// dashboard notification (the bell) alongside the chat message.
+async function announceFeatureOnce(
+  client: SocketClient,
+  feature: FeatureAnnouncement,
+): Promise<boolean> {
+  const cacheKey = `${client.token}:${feature.id}`
+  if (handledCache.has(cacheKey)) return false
+  if (!isFeatureEnabled(client, feature.gateSettingKey)) return false // may enable later; don't cache
+
+  const { data, error } = await supabase
+    .from('settings')
+    .upsert(
+      {
+        userId: client.token,
+        key: `featureAnnounced:${feature.id}`,
+        value: true,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'userId, key', ignoreDuplicates: true },
+    )
+    .select('key')
+
+  // Either it's now recorded (first time) or it was already recorded — never look again.
+  markHandled(cacheKey)
+  if (error || !data?.length) return false // already announced ever, or write failed
+
+  const { error: notifyError } = await supabase
+    .from('notifications')
+    .insert({ userId: client.token, type: 'NEW_FEATURE', isRead: false })
+  if (notifyError) {
+    logger.error('[feature-announce] failed to create dashboard notification', {
+      id: feature.id,
+      error: notifyError,
+    })
+  }
+
+  say(client, t(feature.messageKey, { url: WHATS_NEW_URL, lng: client.locale }))
+  return true
+}
+
+// On a trigger event, announce at most ONE pending feature for this match — so a streamer with
+// several un-seen features (e.g. after a backfill) gets them spread over matches, not in a
+// burst. The per-match guard is a self-correcting Redis key (new matchid → eligible again).
+export async function dispatchFeatureAnnouncements(
+  dotaClient: GSIHandlerType,
+  trigger: string,
+  data: unknown,
+): Promise<void> {
+  const client = dotaClient.client
+  if (!isPlayingMatch(client.gsi)) return
+
+  const matchId = client.gsi?.map?.matchid
+  if (!matchId) return
+
+  const guardKey = `${client.token}:featureAnnouncedMatch`
+  if ((await redisClient.client.get(guardKey)) === String(matchId)) return
+
+  for (const feature of FEATURE_ANNOUNCEMENTS) {
+    if (feature.trigger !== trigger) continue
+    if (feature.when && !feature.when(dotaClient, data)) continue
+    if (await announceFeatureOnce(client, feature)) {
+      await redisClient.client.set(guardKey, String(matchId))
+      return
+    }
+  }
+}
+
+// Register one listener per distinct trigger via the EventHandler wrapper (which fans out to
+// multiple listeners per event), so these coexist with the existing per-event handlers.
+export function registerFeatureAnnouncers(): void {
+  const triggers = [...new Set(FEATURE_ANNOUNCEMENTS.map((f) => f.trigger))]
+  for (const trigger of triggers) {
+    eventHandler.registerEvent(trigger, {
+      handler: (dotaClient, data) => dispatchFeatureAnnouncements(dotaClient, trigger, data),
+    })
+  }
+}

--- a/packages/dota/src/dota/lib/announceFeatures.ts
+++ b/packages/dota/src/dota/lib/announceFeatures.ts
@@ -101,6 +101,10 @@ export async function dispatchFeatureAnnouncements(
   data: unknown,
 ): Promise<void> {
   const client = dotaClient.client
+  // EventHandler already gates events on stream_online; this explicit guard keeps the
+  // dispatcher correct if ever called from another path, and never persists a
+  // featureAnnounced flag (which would suppress the notice forever) for an offline streamer.
+  if (!client.stream_online) return
   if (!isPlayingMatch(client.gsi)) return
 
   const matchId = client.gsi?.map?.matchid

--- a/packages/dota/src/dota/lib/featureAnnouncements.ts
+++ b/packages/dota/src/dota/lib/featureAnnouncements.ts
@@ -1,0 +1,31 @@
+import type { SettingKeys } from '../../settings'
+import type { GSIHandlerType } from '../GSIHandlerTypes'
+
+// One announceable feature. `id` is shared by convention with the frontend `whatsNew`
+// registry (same hand-kept discipline as setting keys, since the two repos have no shared
+// package). The announcer (announceFeatures.ts) fires the chat copy once per streamer at the
+// relevant in-game moment, gated by the master / per-feature toggles.
+export interface FeatureAnnouncement {
+  id: string
+  // GSI event to announce on, e.g. 'hero:id' (pick), 'map:game_state' (match start),
+  // 'player:deaths' (first blood). Multiple features can share a trigger.
+  trigger: string
+  // Optional extra condition on the event payload (e.g. game_state === GAME_IN_PROGRESS).
+  when?: (dotaClient: GSIHandlerType, data: unknown) => boolean
+  // Per-feature tri-state toggle; effective = (value ?? autoOptInNewFeatures). Omit to gate
+  // on the master toggle alone.
+  gateSettingKey?: SettingKeys
+  // i18n key for the chat message (authored with the opt-out framing + {{- url}}).
+  messageKey: string
+  releaseDate: string // ISO; mirrors the frontend entry, handy for future grace windows
+}
+
+export const FEATURE_ANNOUNCEMENTS: FeatureAnnouncement[] = [
+  {
+    id: 'cosmetics',
+    trigger: 'hero:id',
+    gateSettingKey: 'cosmeticsAnnounce',
+    messageKey: 'newFeatures.announce.cosmetics',
+    releaseDate: '2026-06-10',
+  },
+]

--- a/packages/dota/src/types/settings.ts
+++ b/packages/dota/src/types/settings.ts
@@ -128,6 +128,13 @@ export const defaultSettingsStructure = {
   battlepass: false,
   chatter: true,
   chatters: defaultChatters,
+  // Master switch: when on (default), features released after a streamer's last
+  // visit are enabled by default. Per-feature settings (e.g. cosmeticsAnnounce)
+  // override this once explicitly set. See isNewFeatureEnabled-style gating.
+  autoOptInNewFeatures: true,
+  // New-feature toggle for cosmetic-set announcements. null = follow
+  // autoOptInNewFeatures; true/false = explicit streamer choice (always wins).
+  cosmeticsAnnounce: null as boolean | null,
   customMmr: '[currentmmr] | [currentrank] | Next rank at [nextmmr] [wins]',
   'minimap-blocker': true,
   minimapRight: false,

--- a/packages/dota/src/utils/subscription.ts
+++ b/packages/dota/src/utils/subscription.ts
@@ -74,6 +74,8 @@ const FEATURE_TIERS: Record<
   'chatters.neutralItems': SUBSCRIPTION_TIERS.PRO,
   'chatters.dotapatch': SUBSCRIPTION_TIERS.FREE,
   'chatters.chattingSpamEmote': SUBSCRIPTION_TIERS.FREE,
+  autoOptInNewFeatures: SUBSCRIPTION_TIERS.FREE,
+  cosmeticsAnnounce: SUBSCRIPTION_TIERS.FREE,
   aegis: SUBSCRIPTION_TIERS.PRO,
   betsInfo: SUBSCRIPTION_TIERS.PRO,
   customMmr: SUBSCRIPTION_TIERS.PRO,


### PR DESCRIPTION
## What
Generalizes the one-off cosmetic-set notice into a **registry-driven feature-announcement system**: each released feature is announced in Twitch chat at a relevant in-game moment, once per streamer.

- `lib/featureAnnouncements.ts` — registry `{ id, trigger (GSI event), when?, gateSettingKey?, messageKey, releaseDate }`
- `lib/announceFeatures.ts` — dispatcher/announcer: gated by `(perFeature ?? autoOptInNewFeatures)`, durable once-ever per streamer (settings flag `featureAnnounced:<id>`, ON CONFLICT DO NOTHING), **≤1 feature per match**, writes the chat message + a `NEW_FEATURE` notifications row; registrar hooks one listener per trigger via `gsiEventLoader`
- Migrates the cosmetics notice in as the first entry; `hero.id.ts` keeps the per-match set announce
- Settings `autoOptInNewFeatures` + `cosmeticsAnnounce` (+ FEATURE_TIERS); i18n `newFeatures.announce.cosmetics`

## Tests
`announceFeatures.test.ts` (gating, once-ever, ≤1/match, registration) + updated `hero.id.test.ts`. Full `dota` suite green: **66 files, 697 tests**; `vp check` clean (385 files). No DB migrations (settings = key/value rows; `notifications.type` is a free string).

## Deploy
Pairs with the frontend What's New PR (dotabod/frontend#243). **Deploy frontend first or together** — this produces `NEW_FEATURE` notifications + the new settings the frontend renders. Backend is a Coolify hard cutover (single-replica; self-heals in seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)