### PR TITLE
fix(dota): stop paging on non-actionable clip/vision errors

### DIFF
--- a/packages/dota/src/dota/lib/__tests__/createReadyClip.test.ts
+++ b/packages/dota/src/dota/lib/__tests__/createReadyClip.test.ts
@@ -127,6 +127,30 @@ describe('createReadyClip', () => {
     expect(createCalls).toBe(1) // no retries — does not consume maxAttempts
   })
 
+  it('bails immediately without retry when the token is missing the clips:edit scope', async () => {
+    // Twurple's AuthProvider raises this when the broadcaster never granted
+    // clips:edit. It "can not be upgraded" mid-loop, so retrying just spams the
+    // error log — short-circuit instead.
+    let createCalls = 0
+    const scopeError = new Error(
+      'This token does not have any of the requested scopes (clips:edit) and can not be upgraded.',
+    )
+    const api = {
+      clips: {
+        createClip: async () => {
+          createCalls += 1
+          throw scopeError
+        },
+        getClipById: async () => ({ duration: 0 }),
+      },
+    } as any
+
+    const result = await createReadyClip(api, 'acct', FAST_OPTS, '[Test]', {})
+
+    expect(result).toBeNull()
+    expect(createCalls).toBe(1) // no retries — does not consume maxAttempts
+  })
+
   it('catches a clip that only transcodes after several polls (draft window)', async () => {
     // Twitch transcode takes ~15s; the draft path's old 2-poll (~8s) window
     // abandoned the clip mid-transcode and failed ~100% of the time. The clip

--- a/packages/dota/src/dota/lib/clipSchedule.ts
+++ b/packages/dota/src/dota/lib/clipSchedule.ts
@@ -72,7 +72,11 @@ async function createAndSubmitClip(payload: ClipTaskPayload): Promise<void> {
     const clipId = await createReadyClip(api, accountId, opts, logPrefix, logContext)
 
     if (!clipId) {
-      logger.error(`${logPrefix} no usable clip after retries; skipping vision submission`, {
+      // Twitch's CreateClip API silently fails to transcode a large fraction of
+      // the time (see createReadyClip). The feature degrades gracefully here —
+      // we just skip vision submission — so this is expected flakiness, not an
+      // error worth paging on.
+      logger.warn(`${logPrefix} no usable clip after retries; skipping vision submission`, {
         ...logContext,
       })
       return

--- a/packages/dota/src/dota/lib/createReadyClip.ts
+++ b/packages/dota/src/dota/lib/createReadyClip.ts
@@ -30,6 +30,20 @@ function isChannelOfflineError(err: unknown): boolean {
   )
 }
 
+// Twurple's AuthProvider throws when the broadcaster's token is missing the
+// clips:edit scope: "...does not have any of the requested scopes (clips:edit)
+// and can not be upgraded." That's a permanent per-user auth state — the streamer
+// has to re-authorize — so retrying inside the loop can't recover it and just
+// re-logs the same error 2-3x per game state. Short-circuit like the offline case.
+function isMissingScopeError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const message =
+    typeof (err as { message?: unknown }).message === 'string'
+      ? (err as { message: string }).message
+      : ''
+  return /requested scopes|can not be upgraded/i.test(message)
+}
+
 // Twitch's CreateClip API is asynchronous and silently fails to actually produce
 // a clip a large fraction of the time: it returns a clip ID, but the clip never
 // transcodes (duration stays 0, renditions 404) — permanently, not just briefly.
@@ -58,6 +72,13 @@ export async function createReadyClip(
     } catch (error) {
       if (isChannelOfflineError(error)) {
         logger.info(`${logPrefix} createClip skipped — channel offline`, {
+          ...logContext,
+          attempt,
+        })
+        return null
+      }
+      if (isMissingScopeError(error)) {
+        logger.warn(`${logPrefix} createClip skipped — token missing clips:edit scope`, {
           ...logContext,
           attempt,
         })


### PR DESCRIPTION
## Why

The **Dota: error logs detected** watchdog (`count(*) FROM Log WHERE container_name='dota' AND message LIKE '%] error: %' >= 1 for 5 min`) paged Critical at 2026-06-17 18:02 CT. Investigation on the host: dota container `i8gccg8` is **Up 5 days, 0 restarts** — no crash. The page was purely application `error:`-level logs at a low, steady rate (2–29/hr), almost all from the clip→vision feature emitting errors for two conditions it already handles gracefully.

Breakdown over 6h at the time of the page:

| Count | Message | Nature |
|------:|---------|--------|
| 59 | `no usable clip after retries; skipping vision submission` | Twitch didn't transcode the clip; vision is skipped — graceful |
| 16 | `createClip failed … clips:edit … can not be upgraded` | One streamer whose token lacks the scope; retried 2–3× per game state |

## What

1. **Short-circuit the non-upgradeable `clips:edit` scope error** in `createReadyClip`, mirroring the existing offline-channel handling: log once at `warn`, return `null`, skip the remaining retries. A missing scope is a permanent per-user auth state — the streamer must re-authorize — so retrying inside the loop can't recover it and just re-logs the same error 2–3× per game state.
2. **Downgrade `no usable clip after retries` from `error` → `warn`** in `clipSchedule`. Twitch's CreateClip silently fails to transcode a large fraction of the time; the feature degrades gracefully (skips vision submission), so it isn't pageable.

Genuine `createClip` failures still log at `error`. Adds a unit test asserting the missing-scope path bails without consuming retries.

## Not included (follow-ups)
- One streamer (`sneakysniff`) should re-auth with the `clips:edit` scope.
- Consider raising the watchdog threshold (e.g. `>= 5 for 5 min`) so a small background of clip-feature warnings doesn't page.

## Test
- `vp test` on the two affected files: 16 passed (incl. new scope test).
- Full pre-commit suite: 940 passed / 2 skipped; lint + typecheck clean (385 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)