### PR TITLE
fix(dota): smoke double-send dedup + clipping-off note only for !np/!gm/!avg

### DIFF
--- a/packages/dota/locales/en/translation.json
+++ b/packages/dota/locales/en/translation.json
@@ -68,8 +68,6 @@
     "midas": "{{emote}} Use your midas",
     "noTp": "{{channel}} where's your tp {{emote}}",
     "pause": "{{emote}} Who paused the game?",
-    "smokeActivated": "{{- heroName}} activated Smoke of Deceit! {{emote}}",
-    "smokeActivatedUnknown": "{{emote}} An ally activated Smoke of Deceit!",
     "smokeWithoutYou": "team smoking without you {{emote}}",
     "smoked": "{{emote}} {{- heroName}} is smoked!",
     "tpFound": "{{channel}} nice job finally getting a tp after $t(seconds, {\"count\": {{seconds}} }) {{emote}}",

--- a/packages/dota/src/dota/events/gsi-events/__tests__/gsiEvents.integration.test.ts
+++ b/packages/dota/src/dota/events/gsi-events/__tests__/gsiEvents.integration.test.ts
@@ -604,7 +604,7 @@ describe('event:generic_event - smoke activated', () => {
     expect(gsiState.chatSayCalls[0].message).toContain('without you')
   })
 
-  it('announces but does not roast when the streamer is in the smoke', async () => {
+  it('stays silent when the streamer is in the smoke (hero:smoked announces instead)', async () => {
     const handler = makeGsiHandler()
     handler.client.gsi.player.team_name = 'radiant'
     handler.client.gsi.hero = { name: 'npc_dota_hero_lina', smoked: true, alive: true }
@@ -615,11 +615,12 @@ describe('event:generic_event - smoke activated', () => {
     events.emit('event:generic_event', smokeEvent(0), handler.getToken())
     await flushAsync()
 
-    expect(gsiState.chatSayCalls).toHaveLength(1)
-    expect(gsiState.chatSayCalls[0].message).toContain('Smoke of Deceit')
+    // The "<hero> is smoked!" callout is owned by the hero:smoked handler; this handler only
+    // roasts when the streamer is left behind, so it says nothing for an in-smoke streamer.
+    expect(gsiState.chatSayCalls).toHaveLength(0)
   })
 
-  it('does not roast when the streamer cast the smoke themselves', async () => {
+  it('stays silent when the streamer cast the smoke themselves', async () => {
     const handler = makeGsiHandler()
     handler.client.gsi.player.team_name = 'radiant'
     handler.client.gsi.hero = { name: 'npc_dota_hero_lina', smoked: false, alive: true }
@@ -630,25 +631,24 @@ describe('event:generic_event - smoke activated', () => {
     events.emit('event:generic_event', smokeEvent(0), handler.getToken())
     await flushAsync()
 
-    expect(gsiState.chatSayCalls).toHaveLength(1)
-    expect(gsiState.chatSayCalls[0].message).toContain('Smoke of Deceit')
+    // A self-caster is in the smoke by definition — hero:smoked covers it; no roast here.
+    expect(gsiState.chatSayCalls).toHaveLength(0)
   })
 
-  it('announces (does not roast) when the streamer is dead', async () => {
+  it('stays silent when the streamer is dead (not "caught out")', async () => {
     const handler = makeGsiHandler()
     handler.client.gsi.player.team_name = 'radiant'
     handler.client.gsi.hero = { name: 'npc_dota_hero_lina', smoked: false, alive: false }
     registerHandler(handler)
-    // Teammate smoked while the streamer is dead — dead isn't "caught out", so announce.
+    // Teammate smoked while the streamer is dead — a dead player wasn't left behind and
+    // never gets the buff, so neither path has anything to say.
     gsiState.matchPlayers = [{ heroid: 5, accountid: 99999, playerid: 0 }]
     gsiState.redisGet[`${handler.getToken()}:playingHeroSlot`] = '1'
 
     events.emit('event:generic_event', smokeEvent(0), handler.getToken())
     await flushAsync()
 
-    expect(gsiState.chatSayCalls).toHaveLength(1)
-    expect(gsiState.chatSayCalls[0].message).toContain('Smoke of Deceit')
-    expect(gsiState.chatSayCalls[0].message).not.toContain('without you')
+    expect(gsiState.chatSayCalls).toHaveLength(0)
   })
 
   it('does not chat when the activator is on the enemy team', async () => {
@@ -663,6 +663,28 @@ describe('event:generic_event - smoke activated', () => {
     await flushAsync()
 
     expect(gsiState.chatSayCalls).toHaveLength(0)
+  })
+
+  it('does not double-post when a teammate smokes the streamer (hero:smoked + team event)', async () => {
+    const handler = makeGsiHandler()
+    handler.client.gsi.player.team_name = 'radiant'
+    handler.client.gsi.hero = { name: 'npc_dota_hero_lina', smoked: true, alive: true }
+    registerHandler(handler)
+    gsiState.redisGet[`${handler.getToken()}:playingHero`] = 'npc_dota_hero_lina'
+    // Teammate in slot 0 popped it; the streamer (slot 1) is in the smoke.
+    gsiState.matchPlayers = [{ heroid: 5, accountid: 99999, playerid: 0 }]
+    gsiState.redisGet[`${handler.getToken()}:playingHeroSlot`] = '1'
+
+    // The same activation reaches both paths: the hero buff flip and the team chat event.
+    events.emit('hero:smoked', true, handler.getToken())
+    events.emit('event:generic_event', smokeEvent(0), handler.getToken())
+    await flushAsync()
+
+    // Exactly one message — the "is smoked!" callout — and no activator/FOMO line.
+    expect(gsiState.chatSayCalls).toHaveLength(1)
+    expect(gsiState.chatSayCalls[0].message).toContain('is smoked')
+    expect(gsiState.chatSayCalls[0].message).not.toContain('Smoke of Deceit')
+    expect(gsiState.chatSayCalls[0].message).not.toContain('without you')
   })
 })
 

--- a/packages/dota/src/dota/events/gsi-events/event.generic_event.ts
+++ b/packages/dota/src/dota/events/gsi-events/event.generic_event.ts
@@ -4,7 +4,6 @@ import { type ChatEventData, ChatMessageType, type DotaEvent, DotaEventTypes } f
 import { getRedisNumberValue } from '../../../utils/index'
 import { delayedQueue } from '../../lib/DelayedQueue'
 import { isPlayingMatch } from '../../lib/isPlayingMatch'
-import { MatchDataService } from '../../lib/matchData'
 import { say } from '../../say'
 import eventHandler from '../EventHandler'
 
@@ -40,39 +39,28 @@ eventHandler.registerEvent(`event:${DotaEventTypes.GenericEvent}`, {
         const activatorTeam = data.playerid1 <= 4 ? 'radiant' : 'dire'
         if (!streamerTeam || activatorTeam !== streamerTeam) return
 
-        // Did the streamer cast it themselves? Then they're in it by definition.
+        // Did the streamer cast it themselves? Then they're in it by definition — the
+        // hero:smoked handler will say "<hero> is smoked!", so there's nothing to roast.
         const streamerCastIt =
           (await getRedisNumberValue(`${dotaClient.getToken()}:playingHeroSlot`)) === data.playerid1
+        if (streamerCastIt) return
 
-        // Decide ONE message after the smoke buff settles (~3s): rib the streamer if they
-        // weren't actually in it, otherwise name the hero who popped it.
+        // This handler only does the FOMO roast. When the streamer DID make the smoke, the
+        // hero:smoked handler already announces it ("<hero> is smoked!") — staying silent here
+        // is what keeps the two paths from double-posting. After the buff settles (~3s), roast
+        // only if a teammate smoked and the streamer got left behind.
         delayedQueue.addTask(SMOKE_FOMO_DELAY_MS, async () => {
           const { client } = dotaClient
           if (!client.stream_online) return
           if (!isPlayingMatch(client.gsi)) return
 
           // Caught out: a teammate smoked, the streamer is alive, but never got the buff.
-          const caughtOut =
-            !streamerCastIt && client.gsi?.hero?.alive !== false && !client.gsi?.hero?.smoked
+          const caughtOut = client.gsi?.hero?.alive !== false && !client.gsi?.hero?.smoked
           if (caughtOut) {
             say(client, t('chatters.smokeWithoutYou', { emote: 'HAH', lng: client.locale }), {
               chattersKey: 'smokeActivated',
             })
-            return
           }
-
-          // Grouped up (or cast it): name the activator's hero, tier-aware (8500+ stays
-          // anonymous). resolveHeroNameForSlot does the roster lookup + bounded color fallback.
-          const { name: heroName } = await new MatchDataService(client).resolveHeroNameForSlot({
-            eventPlayerId: data.playerid1,
-          })
-          say(
-            client,
-            heroName
-              ? t('chatters.smokeActivated', { emote: 'Shush', heroName, lng: client.locale })
-              : t('chatters.smokeActivatedUnknown', { emote: 'Shush', lng: client.locale }),
-            { chattersKey: 'smokeActivated' },
-          )
         })
         return
       }

--- a/packages/dota/src/twitch/chatClient.ts
+++ b/packages/dota/src/twitch/chatClient.ts
@@ -85,6 +85,14 @@ export const chatClient = {
       twitchChat.emit('say', user?.Account?.providerAccountId, finalText, reply_parent_message_id)
     }
   },
+  // Like `say`, but drops any pending command-suggestion suffix first. For
+  // "nothing to show" replies (e.g. the auto-clipping-disabled note) where a
+  // trailing "Also try !x" would point viewers at an equally-dataless sibling.
+  sayWithoutSuggestion: (channel: string, text: string, reply_parent_message_id?: string): void => {
+    const ctx = suggestionContext.getStore()
+    if (ctx) ctx.suffix = null
+    chatClient.say(channel, text, reply_parent_message_id)
+  },
   whisper: (channel: string, text: string | undefined) => {
     whisperQueue.push({ channel, text: text || 'Empty whisper message, monka' })
     void processQueue()

--- a/packages/dota/src/twitch/commands/avg.ts
+++ b/packages/dota/src/twitch/commands/avg.ts
@@ -5,7 +5,7 @@ import { MatchDataService } from '../../dota/lib/matchData'
 import { DBSettings } from '../../settings'
 import { chatClient } from '../chatClient'
 import commandHandler from '../lib/CommandHandler'
-import { clippingDisabledNote, withClippingNote } from '../lib/clippingNote'
+import { clippingDisabledNote } from '../lib/clippingNote'
 
 commandHandler.registerCommand('avg', {
   onlyOnline: true,
@@ -32,6 +32,12 @@ commandHandler.registerCommand('avg', {
 
     const roster = await new MatchDataService(client).resolveRoster()
     const note = clippingDisabledNote(client, roster.players)
+    // No clip/vision data to read at 8500+ with auto-clipping off — the note IS
+    // the whole reply; don't prepend a meaningless average.
+    if (note) {
+      chatClient.sayWithoutSuggestion(message.channel.name, note, message.user.messageId)
+      return
+    }
 
     calculateAvg({
       locale: client.locale,
@@ -39,16 +45,12 @@ commandHandler.registerCommand('avg', {
       players: roster.players,
     })
       .then((avg) => {
-        chatClient.say(
-          message.channel.name,
-          withClippingNote(`${avg}${avgDescriptor}`, note),
-          message.user.messageId,
-        )
+        chatClient.say(message.channel.name, `${avg}${avgDescriptor}`, message.user.messageId)
       })
       .catch((e) => {
         chatClient.say(
           message.channel.name,
-          withClippingNote(e?.message ?? t('gameNotFound', { lng: client.locale }), note),
+          e?.message ?? t('gameNotFound', { lng: client.locale }),
           message.user.messageId,
         )
       })

--- a/packages/dota/src/twitch/commands/gm.ts
+++ b/packages/dota/src/twitch/commands/gm.ts
@@ -5,7 +5,7 @@ import { DBSettings } from '../../settings'
 import { gameMedals } from '../../steam/medals'
 import { chatClient } from '../chatClient'
 import commandHandler from '../lib/CommandHandler'
-import { clippingDisabledNote, withClippingNote } from '../lib/clippingNote'
+import { clippingDisabledNote } from '../lib/clippingNote'
 
 commandHandler.registerCommand('gm', {
   aliases: ['medals', 'ranks'],
@@ -31,18 +31,21 @@ commandHandler.registerCommand('gm', {
 
     const roster = await new MatchDataService(client).resolveRoster()
     const note = clippingDisabledNote(client, roster.players)
+    // No clip/vision data to read at 8500+ with auto-clipping off — the note IS
+    // the whole reply; don't prepend the all-"Unknown" medal dump.
+    if (note) {
+      chatClient.sayWithoutSuggestion(message.channel.name, note, message.user.messageId)
+      return
+    }
 
     gameMedals(client.locale, message.channel.client.gsi?.map?.matchid, roster.players)
       .then((desc) => {
-        chatClient.say(message.channel.name, withClippingNote(desc, note), message.user.messageId)
+        chatClient.say(message.channel.name, desc, message.user.messageId)
       })
       .catch((e) => {
         chatClient.say(
           message.channel.name,
-          withClippingNote(
-            e?.message ?? t('gameNotFound', { lng: message.channel.client.locale }),
-            note,
-          ),
+          e?.message ?? t('gameNotFound', { lng: message.channel.client.locale }),
           message.user.messageId,
         )
       })

--- a/packages/dota/src/twitch/commands/np.ts
+++ b/packages/dota/src/twitch/commands/np.ts
@@ -8,7 +8,7 @@ import type { NotablePlayers } from '../../steam/notableplayers'
 import { notablePlayers } from '../../steam/notableplayers'
 import { chatClient } from '../chatClient'
 import commandHandler from '../lib/CommandHandler'
-import { clippingDisabledNote, withClippingNote } from '../lib/clippingNote'
+import { clippingDisabledNote } from '../lib/clippingNote'
 
 commandHandler.registerCommand('np', {
   dbkey: DBSettings.commandNP,
@@ -137,6 +137,12 @@ commandHandler.registerCommand('np', {
     const mds = new MatchDataService(client)
     const roster = await mds.resolveRoster()
     const note = clippingDisabledNote(client, roster.players)
+    // No clip/vision data to read at 8500+ with auto-clipping off — the note IS
+    // the whole reply; don't prepend the empty "[heroes not found]: …" roster.
+    if (note) {
+      chatClient.sayWithoutSuggestion(channel, note, message.user.messageId)
+      return
+    }
     const enableCountries = getValueOrDefault(
       DBSettings.notablePlayersOverlayFlagsCmd,
       client.settings,
@@ -167,15 +173,12 @@ commandHandler.registerCommand('np', {
             description = `${description} · ${t('streamersSuffix', { count, lng: client.locale })}`
           }
         }
-        chatClient.say(channel, withClippingNote(description, note), message.user.messageId)
+        chatClient.say(channel, description, message.user.messageId)
       })
       .catch((e) => {
         chatClient.say(
           channel,
-          withClippingNote(
-            e?.message ?? t('gameNotFound', { lng: message.channel.client.locale }),
-            note,
-          ),
+          e?.message ?? t('gameNotFound', { lng: message.channel.client.locale }),
           message.user.messageId,
         )
       })

--- a/packages/dota/src/twitch/lib/__tests__/clippingNote.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/clippingNote.test.ts
@@ -14,7 +14,7 @@ vi.doMock('@dotabod/shared-utils', () => buildSharedUtilsMock({ supabase: {}, lo
 
 await initTestI18n()
 
-const { clippingDisabledNote, withClippingNote } = await import('../clippingNote.ts')
+const { clippingDisabledNote } = await import('../clippingNote.ts')
 
 function makeClient(over: Partial<SocketClient> = {}): SocketClient {
   return {
@@ -64,15 +64,5 @@ describe('clippingDisabledNote', () => {
     // streamer's own hero (gsi-self source), which must not be mistaken for a real roster.
     const note = clippingDisabledNote(makeClient(), selfOnlyFallback)
     expect(note).toContain('auto-clipping')
-  })
-})
-
-describe('withClippingNote', () => {
-  it('appends the note as a postfix when present', () => {
-    expect(withClippingNote('No notable players', 'nope')).toBe('No notable players · nope')
-  })
-
-  it('returns the text unchanged when the note is empty', () => {
-    expect(withClippingNote('No notable players', '')).toBe('No notable players')
   })
 })

--- a/packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts
@@ -334,3 +334,41 @@ describe('!avg', () => {
     expect(state.chatSayCalls[0].message).toBe(multiAccount)
   })
 })
+
+describe('auto-clipping disabled at 8500+ (no readable game data)', () => {
+  // At 8500+ Valve provides no realtime roster, so !np/!gm/!avg read hero & rank
+  // data only from the auto-clip vision pipeline. With clipping off there's
+  // nothing to read, so each must reply with ONLY the explanation — no junk
+  // "[heroes not found]: …" / "…: Unknown" dump (and no "Also try" suffix).
+  const clippingDisabled = t('clippingDisabled', { lng: 'en' })
+  // mmr 9000 → is8500Plus; gsi undefined → every roster resolver no-ops → empty
+  // roster → clippingDisabledNote fires.
+  const noData = {
+    mmr: 9000,
+    settings: [{ key: 'disableAutoClipping', value: true }],
+    gsi: undefined,
+  } as any
+
+  it('!np replies with only the clipping-disabled note', async () => {
+    await commandHandler.handleMessage(makeMessage({ content: '!np', clientOverrides: noData }))
+    await flushAsync()
+    expect(state.chatSayCalls).toHaveLength(1)
+    expect(state.chatSayCalls[0].message).toBe(clippingDisabled)
+    expect(state.chatSayCalls[0].message).not.toContain('heroes not found')
+  })
+
+  it('!gm replies with only the clipping-disabled note', async () => {
+    await commandHandler.handleMessage(makeMessage({ content: '!gm', clientOverrides: noData }))
+    await flushAsync()
+    expect(state.chatSayCalls).toHaveLength(1)
+    expect(state.chatSayCalls[0].message).toBe(clippingDisabled)
+    expect(state.chatSayCalls[0].message).not.toContain('Unknown')
+  })
+
+  it('!avg replies with only the clipping-disabled note', async () => {
+    await commandHandler.handleMessage(makeMessage({ content: '!avg', clientOverrides: noData }))
+    await flushAsync()
+    expect(state.chatSayCalls).toHaveLength(1)
+    expect(state.chatSayCalls[0].message).toBe(clippingDisabled)
+  })
+})

--- a/packages/dota/src/twitch/lib/clippingNote.ts
+++ b/packages/dota/src/twitch/lib/clippingNote.ts
@@ -28,8 +28,3 @@ export function clippingDisabledNote(client: SocketClient, matchPlayers: RosterP
 
   return t('clippingDisabled', { lng: client.locale })
 }
-
-// Append the note as a " · " postfix when present.
-export function withClippingNote(text: string, note: string): string {
-  return note ? `${text} · ${note}` : text
-}


### PR DESCRIPTION
> **Note:** this PR bundles two independent dota changes (disjoint files) per request — the smoke double-send fix (§1) plus an auto-clipping-off note tweak from a parallel session (§2).

## 1. Smoke alert double-send

The smoke chat system was double-posting when a teammate activated smoke on the streamer: both the `generic_event` handler (announcing the activator) and `hero:smoked` handler (announcing the buff) would fire simultaneously.

**Solution:** Clarify handler ownership:
- `hero:smoked`: announces "<hero> is smoked!" when streamer gains the buff
- `generic_event`: only roasts "team smoking without you" when streamer is left behind

The `generic_event` handler now returns early if the streamer self-cast (since `hero:smoked` will handle it) and only proceeds to the delayed roast check. It no longer announces the activator's name.

**Changes:**
- Removed unused translations `smokeActivated` and `smokeActivatedUnknown`
- Removed hero-name-resolution and `MatchDataService` from `event.generic_event`
- Simplified handler to only roast on the "caught out" path (alive, no buff)
- Updated tests to verify no double-post and proper silence in non-roast scenarios

## 2. Auto-clipping-off note only for !np/!gm/!avg

> From a parallel session — bundled here per request. Shows only the "auto-clipping disabled" note for `!np` / `!gm` / `!avg` instead of appending a command-suggestion suffix that would point viewers at an equally data-less sibling. Adds `chatClient.sayWithoutSuggestion`, drops `withClippingNote`.

## Testing
- `vp check` (format / lint / typecheck) — clean.
- `vp test` on affected files — **79 passed** (smoke + clipping integration/unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
