### PR TITLE
fix(twitch-chat): stop EventSub socket leak behind the 429 connection storm

### DIFF
--- a/packages/twitch-chat/src/__tests__/eventSubSocket.test.ts
+++ b/packages/twitch-chat/src/__tests__/eventSubSocket.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+// Route through the shared harness so `ws` and `@dotabod/shared-utils` are
+// mocked once, process-wide, without competing factories.
+import { EventsubSocket, FakeWebSocket, isEventsubConnected } from './sharedMocks.ts'
+
+const welcomeMsg = (id = 'sess-1', keepalive = 10) => ({
+  metadata: { message_type: 'session_welcome' },
+  payload: { session: { id, keepalive_timeout_seconds: keepalive } },
+})
+const keepaliveMsg = () => ({ metadata: { message_type: 'session_keepalive' }, payload: {} })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  FakeWebSocket.reset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('EventsubSocket lifecycle', () => {
+  it('connects on construction and reports connected after session_welcome', () => {
+    const sock = new EventsubSocket()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    FakeWebSocket.latest().open()
+    FakeWebSocket.latest().message(welcomeMsg())
+    expect(isEventsubConnected()).toBe(true)
+
+    sock.dispose()
+  })
+
+  it('dispose() makes the socket inert: a late close neither flips the flag nor reconnects', async () => {
+    const sock = new EventsubSocket()
+    FakeWebSocket.latest().open()
+    FakeWebSocket.latest().message(welcomeMsg())
+    expect(isEventsubConnected()).toBe(true)
+
+    const ws = FakeWebSocket.latest()
+    sock.dispose()
+    expect(sock.isDisposed).toBe(true)
+
+    // The leak that caused the storm: a retired socket that still reacts to
+    // closes (reconnecting) and writes the shared flag. After dispose, neither
+    // must happen.
+    ws.serverClose(1006)
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(isEventsubConnected()).toBe(true) // unchanged by the disposed socket
+    expect(FakeWebSocket.instances).toHaveLength(1) // no reconnect
+  })
+
+  it('dispose() cancels a pending reconnect timer', async () => {
+    const sock = new EventsubSocket()
+    FakeWebSocket.latest().serverClose(1006) // schedules a reconnect
+    sock.dispose()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(FakeWebSocket.instances).toHaveLength(1) // reconnect never fired
+  })
+
+  it('caps the reconnect backoff so the delay stays bounded', async () => {
+    const sock = new EventsubSocket()
+    // Uncapped, backoff (hence delay) grows without bound and a fixed advance
+    // eventually stops triggering reconnects. Capped, every reconnect fires
+    // within MAX_BACKOFF * 100ms, so a 1s advance keeps producing them.
+    for (let i = 0; i < 25; i++) {
+      FakeWebSocket.latest().serverClose(1006)
+      await vi.advanceTimersByTimeAsync(1000)
+    }
+    expect(FakeWebSocket.instances).toHaveLength(26) // 1 initial + 25 reconnects
+    sock.dispose()
+  })
+
+  it('resets backoff after a successful open', async () => {
+    const sock = new EventsubSocket()
+    for (let i = 0; i < 6; i++) {
+      FakeWebSocket.latest().serverClose(1006)
+      await vi.advanceTimersByTimeAsync(1000)
+    }
+    // A successful open resets backoff to 0, so the next reconnect fires within
+    // ~100ms rather than the elevated delay.
+    FakeWebSocket.latest().open()
+    const before = FakeWebSocket.instances.length
+    FakeWebSocket.latest().serverClose(1006)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(FakeWebSocket.instances).toHaveLength(before + 1)
+    sock.dispose()
+  })
+
+  it('backs off hard on HTTP 429 instead of reconnecting immediately', async () => {
+    const sock = new EventsubSocket()
+    // ws surfaces a rejected upgrade as an error then a 1006 close.
+    FakeWebSocket.latest().error('Unexpected server response: 429')
+    FakeWebSocket.latest().serverClose(1006)
+
+    // Cooldown is 15–30s (jittered); nothing should reconnect within 14s.
+    await vi.advanceTimersByTimeAsync(14_000)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    // After the full cooldown it reconnects exactly once.
+    await vi.advanceTimersByTimeAsync(16_000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    sock.dispose()
+  })
+
+  it('on silence: emits session_silenced, marks down, and does not self-reconnect', async () => {
+    const sock = new EventsubSocket()
+    FakeWebSocket.latest().open()
+    FakeWebSocket.latest().message(welcomeMsg('sess-1', 10)) // silence window = 11s
+    expect(isEventsubConnected()).toBe(true)
+
+    let silenced = 0
+    sock.on('session_silenced', () => {
+      silenced++
+    })
+
+    const ws = FakeWebSocket.latest()
+    await vi.advanceTimersByTimeAsync(11_000)
+    expect(silenced).toBe(1)
+    expect(isEventsubConnected()).toBe(false)
+
+    // The silenced socket disabled its own reconnect (the conduitSetup backstop
+    // owns recovery), so a subsequent close must NOT spin up a competing socket.
+    ws.serverClose(1000)
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    sock.dispose()
+  })
+
+  it('a keepalive resets the silence timer and keeps the connection live', async () => {
+    const sock = new EventsubSocket()
+    FakeWebSocket.latest().open()
+    FakeWebSocket.latest().message(welcomeMsg('sess-1', 10))
+
+    // Just before the 11s window closes, a keepalive resets it.
+    await vi.advanceTimersByTimeAsync(10_000)
+    FakeWebSocket.latest().message(keepaliveMsg())
+    // 20s total elapsed, but the timer was rearmed at 10s, so no silence yet.
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(isEventsubConnected()).toBe(true)
+
+    sock.dispose()
+  })
+})

--- a/packages/twitch-chat/src/__tests__/sharedMocks.ts
+++ b/packages/twitch-chat/src/__tests__/sharedMocks.ts
@@ -128,6 +128,60 @@ vi.doMock('../utils/socketManager', () => ({
   },
 }))
 
+// Minimal controllable stand-in for the `ws` WebSocket so EventsubSocket tests
+// can drive open/message/close/error synchronously with no real network. Tests
+// reach the live instance via FakeWebSocket.latest() and reset between cases.
+export class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  static reset() {
+    FakeWebSocket.instances = []
+  }
+  static latest(): FakeWebSocket {
+    return FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+  }
+  url: string
+  readyState: number = FakeWebSocket.CONNECTING
+  private handlers: Record<string, Array<(ev: unknown) => void>> = {}
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  addEventListener(type: string, cb: (ev: unknown) => void) {
+    const list = this.handlers[type] ?? (this.handlers[type] = [])
+    list.push(cb)
+  }
+  removeAllListeners() {
+    this.handlers = {}
+  }
+  close() {
+    if (this.readyState !== FakeWebSocket.CLOSED) this.readyState = FakeWebSocket.CLOSING
+  }
+  send() {}
+  private fire(type: string, ev: Record<string, unknown>) {
+    for (const cb of this.handlers[type] ?? []) cb({ target: this, ...ev })
+  }
+  open() {
+    this.readyState = FakeWebSocket.OPEN
+    this.fire('open', {})
+  }
+  message(obj: unknown) {
+    this.fire('message', { data: JSON.stringify(obj) })
+  }
+  error(message: string) {
+    this.fire('error', { message, type: 'error' })
+  }
+  serverClose(code = 1006, wasClean = false) {
+    this.readyState = FakeWebSocket.CLOSED
+    this.fire('close', { code, reason: '', wasClean })
+  }
+}
+
+vi.doMock('ws', () => ({ default: FakeWebSocket }))
+
 // Route fetch through state so each test controls the HTTP response.
 globalThis.fetch = (async (url: string, options: RequestInit | undefined) => {
   state.fetchCalls.push({ url, options })
@@ -149,5 +203,8 @@ export const { offlineEvent } = await import('../event-handlers/offlineEvent')
 export const { updateUserEvent } = await import('../event-handlers/updateUserEvent')
 export const { sendTwitchChatMessage, handleChatMessage, clearDedupeCache } =
   await import('../handleChat')
+// EventSub socket SUT — imported here (after the `ws` mock above) so the tests
+// drive the controllable FakeWebSocket instead of a real connection.
+export const { EventsubSocket, isEventsubConnected } = await import('../eventSubSocket')
 
 export const flushMacrotasks = () => new Promise<void>((r) => setTimeout(r, 5))

--- a/packages/twitch-chat/src/conduitSetup.ts
+++ b/packages/twitch-chat/src/conduitSetup.ts
@@ -28,6 +28,10 @@ const eventsSocket = twitchEvent
 // EventSub re-establishes on its own the moment twitch-events comes back.
 let eventSubInitInFlight = false
 
+// The one live EventsubSocket. initializeSocket() disposes this before creating
+// its replacement so re-init paths can never accumulate sockets.
+let currentSocket: EventsubSocket | null = null
+
 async function ensureEventSubInitialized(reason: string): Promise<void> {
   if (eventSubInitInFlight) return
   // A plain socket.io reconnect while EventSub is already live needs no re-init.
@@ -303,9 +307,20 @@ async function initializeSocket() {
       conduitId: `${conduitId.substring(0, 8)}...`,
     })
 
+    // Exactly one live EventsubSocket at a time. Every re-init path (startup,
+    // eventsSocket reconnect, watchdog, session_silenced) used to leak the
+    // previous socket; thousands accumulated over ~10 days of uptime, each
+    // reconnect-looping, and their combined connection rate got the bot 429'd by
+    // Twitch (connection storm, 2026-06-19). Disposing the prior socket here —
+    // only once we have a fresh conduit and are about to replace it — makes
+    // every re-init idempotent. (If getConduitId() throws above we keep the
+    // existing socket rather than tearing down a working connection.)
+    currentSocket?.dispose()
+
     const mySocket = new EventsubSocket({
       disableAutoReconnect: false, // Ensure auto reconnect is enabled
     })
+    currentSocket = mySocket
 
     mySocket.on('connected', async (session_id: string) => {
       logger.info('[TWITCHCHAT] Socket connected (initial)', {
@@ -330,26 +345,15 @@ async function initializeSocket() {
       })
     })
 
-    // Safety net: if Twitch goes silent and the close path doesn't recover the
-    // socket (we've seen the connection get stuck with eventsubConnected=false
-    // and no log activity), force a full re-init.
-    let silencedRecoveryInFlight = false
+    // Safety net: when Twitch goes silent the socket disables its own reconnect
+    // (so it can't fight its replacement over the single conduit shard) and we
+    // do one guarded re-init here. ensureEventSubInitialized's in-flight guard,
+    // plus the dispose-on-reinit above, mean repeated silences can't pile up
+    // sockets the way the old direct initializeSocket() call did.
     mySocket.on('session_silenced', () => {
-      if (silencedRecoveryInFlight) {
-        logger.warn('[TWITCHCHAT] session_silenced fired again while recovery in flight')
-        return
-      }
-      silencedRecoveryInFlight = true
-      logger.warn('[TWITCHCHAT] session_silenced — forcing full re-init in 5s')
+      logger.warn('[TWITCHCHAT] session_silenced — re-initializing in 5s')
       setTimeout(() => {
-        initializeSocket()
-          .then(() => logger.info('[TWITCHCHAT] Re-init after silence completed'))
-          .catch((e) =>
-            logger.error('[TWITCHCHAT] Re-init after silence failed', { error: e?.message }),
-          )
-          .finally(() => {
-            silencedRecoveryInFlight = false
-          })
+        void ensureEventSubInitialized('session_silenced')
       }, 5000)
     })
 

--- a/packages/twitch-chat/src/eventSubSocket.ts
+++ b/packages/twitch-chat/src/eventSubSocket.ts
@@ -2,6 +2,21 @@ import { EventEmitter } from 'node:events'
 import { logger } from '@dotabod/shared-utils'
 import WebSocket from 'ws'
 
+// Cap the reconnect backoff factor. The generic branch used to grow this
+// unbounded; combined with leaked sockets that pushed it into the hundreds
+// (delays of tens of seconds) while thousands of instances hammered Twitch in
+// aggregate and got the bot 429'd (connection storm, 2026-06-19).
+const MAX_BACKOFF = 10
+// When Twitch rate-limits the websocket upgrade (HTTP 429) we must back off hard
+// rather than immediately retrying, or we feed the very storm that caused it.
+const RATE_LIMIT_COOLDOWN_MS = 30_000
+
+// Spread reconnects across 50%–100% of the base delay so many sockets (or many
+// processes) can't reconnect in lockstep and thunder the endpoint.
+function withJitter(baseMs: number): number {
+  return Math.round(baseMs * (0.5 + Math.random() * 0.5))
+}
+
 type EventsubSocketOptions = {
   url?: string
   connect?: boolean
@@ -54,7 +69,15 @@ export class EventsubSocket extends EventEmitter {
     is_reconnecting?: boolean
   }
   private silenceHandler?: NodeJS.Timeout
+  private reconnectTimer?: NodeJS.Timeout
   private silenceTime = 10
+  // Once disposed, every callback short-circuits and no new connect is made, so
+  // a replaced socket can't keep reconnecting, re-registering the shard, or
+  // writing the shared eventsubConnected flag in the background.
+  private disposed = false
+  // Set when the last upgrade failed with HTTP 429 so handleClose can apply the
+  // rate-limit cooldown instead of an immediate reconnect.
+  private got429 = false
 
   constructor({
     url = 'wss://eventsub.wss.twitch.tv/ws',
@@ -73,6 +96,7 @@ export class EventsubSocket extends EventEmitter {
   }
 
   private connect(url = this.mainUrl, isReconnect = false): void {
+    if (this.disposed) return
     this.counter++
     this.eventsub = new WebSocket(url) as WebSocket & { counter?: number }
     this.eventsub.counter = this.counter
@@ -84,7 +108,9 @@ export class EventsubSocket extends EventEmitter {
   }
 
   private handleOpen(): void {
+    if (this.disposed) return
     this.backoff = 0
+    this.got429 = false
     logger.info('[EVENTSUB] WebSocket open', {
       counter: this.eventsub.counter,
       url: this.mainUrl,
@@ -92,6 +118,7 @@ export class EventsubSocket extends EventEmitter {
   }
 
   private handleClose(close: WebSocket.CloseEvent, _isReconnect: boolean): void {
+    if (this.disposed) return
     const reasonText = this.closeCodes[close.code] || 'Unknown'
     const isStale = close.target !== this.eventsub
     const wsId = this.eventsub.twitch_websocket_id
@@ -119,15 +146,37 @@ export class EventsubSocket extends EventEmitter {
       counter: this.eventsub.counter,
     })
 
+    // A socket told to stay down (e.g. after session_silenced — the conduitSetup
+    // backstop owns recovery from there) must not reconnect itself, or we end up
+    // with two live sockets fighting over the single conduit shard.
+    if (this.disableAutoReconnect) {
+      logger.warn('[EVENTSUB] Auto-reconnect disabled — staying down', { code: close.code })
+      return
+    }
+
+    this.backoff = Math.min(this.backoff + 1, MAX_BACKOFF)
+
+    // HTTP 429 on the upgrade surfaces as an error then a 1006 close. Back off
+    // hard so a single socket can't pile onto Twitch's rate limit.
+    if (this.got429) {
+      this.got429 = false
+      const delay = withJitter(RATE_LIMIT_COOLDOWN_MS)
+      logger.warn('[EVENTSUB] Reconnecting after 429 (rate limited)', {
+        delayMs: delay,
+        twitchWsId: wsId,
+      })
+      this.scheduleReconnect(delay)
+      return
+    }
+
     if (close.code === 4003) {
-      // Use exponential backoff for 4003 error (connection unused)
-      this.backoff = Math.min(this.backoff + 1, 5) // Cap backoff factor at 5
-      const reconnectDelay = this.backoff * this.backoffStack
+      // Connection unused — Twitch closes a session with no active shard.
+      const delay = withJitter(this.backoff * this.backoffStack)
       logger.info('[EVENTSUB] Reconnecting after 4003 (connection unused)', {
         backoff: this.backoff,
-        delayMs: reconnectDelay,
+        delayMs: delay,
       })
-      setTimeout(() => this.connect(this.mainUrl, true), reconnectDelay)
+      this.scheduleReconnect(delay)
       return
     }
 
@@ -136,37 +185,47 @@ export class EventsubSocket extends EventEmitter {
       // session_reconnect handed off, in which case the stale check above
       // already skipped us. Reaching this branch means it's the *current*
       // socket — we must reconnect or we'll be stuck silent.
+      const delay = withJitter(this.backoff * this.backoffStack)
       logger.warn(
         '[EVENTSUB] 4004 on live socket — reconnect grace expired without handoff, retrying',
-        { backoff: this.backoff, twitchWsId: wsId },
+        { backoff: this.backoff, delayMs: delay, twitchWsId: wsId },
       )
-      this.backoff++
-      setTimeout(() => this.connect(this.mainUrl, true), this.backoff * this.backoffStack)
+      this.scheduleReconnect(delay)
       return
     }
 
-    if (!this.disableAutoReconnect) {
-      this.backoff++
-      logger.info('[EVENTSUB] Scheduling reconnect', {
-        code: close.code,
-        backoff: this.backoff,
-        delayMs: this.backoff * this.backoffStack,
-      })
-      setTimeout(() => this.connect(this.mainUrl, true), this.backoff * this.backoffStack)
-    } else {
-      logger.warn('[EVENTSUB] Auto-reconnect disabled — staying down', { code: close.code })
-    }
+    const delay = withJitter(this.backoff * this.backoffStack)
+    logger.info('[EVENTSUB] Scheduling reconnect', {
+      code: close.code,
+      backoff: this.backoff,
+      delayMs: delay,
+    })
+    this.scheduleReconnect(delay)
+  }
+
+  // Single reconnect path: only ever one pending timer per socket, and it's
+  // cleared on dispose so a replaced socket can't resurrect itself.
+  private scheduleReconnect(delayMs: number): void {
+    clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = setTimeout(() => this.connect(this.mainUrl, true), delayMs)
   }
 
   private handleError(err: WebSocket.ErrorEvent): void {
+    if (this.disposed) return
+    // ws surfaces a rejected upgrade as "Unexpected server response: 429".
+    // Flag it so the following close applies the rate-limit cooldown.
+    const rateLimited = typeof err.message === 'string' && err.message.includes('429')
+    if (rateLimited) this.got429 = true
     logger.error('[EVENTSUB] WebSocket error', {
       message: err.message,
       type: err.type,
       counter: this.eventsub.counter,
+      rateLimited,
     })
   }
 
   private handleMessage(message: WebSocket.MessageEvent): void {
+    if (this.disposed) return
     const data = JSON.parse(message.data as string)
     const { metadata, payload } = data
     const { message_type } = metadata
@@ -244,6 +303,7 @@ export class EventsubSocket extends EventEmitter {
   }
 
   private silence(keepalive_timeout_seconds?: number): void {
+    if (this.disposed) return
     if (keepalive_timeout_seconds) {
       this.silenceTime = keepalive_timeout_seconds + 1
     }
@@ -252,6 +312,7 @@ export class EventsubSocket extends EventEmitter {
     eventsubConnected = true
     clearTimeout(this.silenceHandler)
     this.silenceHandler = setTimeout(() => {
+      if (this.disposed) return
       eventsubConnected = false
       logger.warn('[EVENTSUB] session_silenced — no keepalive in window', {
         silenceTimeSec: this.silenceTime,
@@ -260,6 +321,10 @@ export class EventsubSocket extends EventEmitter {
         counter: this.eventsub.counter,
         willClose: this.silenceReconnect,
       })
+      // The conduitSetup session_silenced backstop owns recovery (a single
+      // guarded re-init that disposes this socket). Disable self-reconnect so
+      // closing below doesn't also spin up a competing socket.
+      this.disableAutoReconnect = true
       this.emit('session_silenced')
       if (this.silenceReconnect) {
         this.close()
@@ -273,5 +338,37 @@ export class EventsubSocket extends EventEmitter {
 
   public close(): void {
     this.eventsub.close()
+  }
+
+  public get isDisposed(): boolean {
+    return this.disposed
+  }
+
+  /**
+   * Permanently retire this socket: stop reconnecting, drop every timer and
+   * listener, and close the underlying websocket. Idempotent. Call this before
+   * replacing a socket so retired instances can't keep reconnecting,
+   * re-registering the conduit shard, or writing the shared connection flag in
+   * the background — the leak that produced the 2026-06-19 connection storm.
+   */
+  public dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.disableAutoReconnect = true
+    clearTimeout(this.silenceHandler)
+    clearTimeout(this.reconnectTimer)
+    const ws = this.eventsub
+    try {
+      ws?.removeAllListeners()
+      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        ws.close()
+      }
+    } catch (error) {
+      logger.warn('[EVENTSUB] Error while disposing socket', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+    this.removeAllListeners()
+    logger.info('[EVENTSUB] Socket disposed', { counter: ws?.counter })
   }
 }


### PR DESCRIPTION
## Problem

The `[Twitch EventSub (bot to Twitch)]` Kuma monitor was flapping Down/Up every ~4–10 min. Pulling the live `twitch-chat` container logs showed the real cause: a **self-inflicted HTTP 429 connection storm driven by a socket leak**.

`initializeSocket()` creates a new `EventsubSocket` on every re-init path — startup, `eventsSocket` reconnect, the 30s watchdog, and the `session_silenced` backstop — but **never disposed the previous one**. Each leaked socket kept auto-reconnecting forever (held alive by its own reconnect timer), so over ~10 days of uptime thousands accumulated. Their combined **~300 connections/sec** to `wss://eventsub.wss.twitch.tv/ws` got the bot **429'd**, which kept anything from connecting, which made the watchdog + silence backstop spawn *even more* sockets — a runaway feedback loop.

Measured in prod (2026-06-19, 6 min window): **~36.8k** `Unexpected server response: 429`, **~36.9k** reconnects, `backoff` climbed past **230** (delays of tens of seconds, uncapped). The single conduit shard (`id: 0`) means only one session can receive events, so the leaked sockets also fought over it. The prior reliability commits (`5821b533`, `dc92bbdd`, `4e792328`, `c86ded6e`) each *added* a re-init call site, which accelerated the leak.

> **Production note:** the storm was live today. I restarted `zwgkg48` to stop the bleeding (it cleared instantly — one clean socket, events flowing, 0 × 429). That's temporary; on the old code the leak rebuilds over days. **This PR is the permanent fix and should be deployed before then.**

## Fix

Enforce exactly one live socket, and make a single socket incapable of storming Twitch.

**`eventSubSocket.ts`**
- `dispose()` + a `disposed` guard on every callback (`connect`/`handleOpen`/`handleClose`/`handleMessage`/`handleError`/`silence`) so a retired socket can't reconnect, re-register the shard, or write the shared `eventsubConnected` flag. One tracked reconnect timer, cleared on dispose.
- Reconnect backoff is now **capped** (`MAX_BACKOFF = 10`) and **jittered** (it was unbounded — that's how it reached 230+).
- An HTTP 429 upgrade is treated as a **30s jittered cooldown**, not an instant retry.
- On silence, the socket disables its own reconnect so it can't fight its replacement.

**`conduitSetup.ts`**
- Module-level `currentSocket`, **disposed before each re-init** → every re-init path is now idempotent and the leak can't form (the core fix).
- `session_silenced` routed through the guarded `ensureEventSubInitialized` instead of a raw `initializeSocket()`, so recovery has a single owner.

## Tests

There were **no** tests for the socket lifecycle (which is how these concurrency bugs accumulated across successive fixes). Adds `eventSubSocket.test.ts` — 8 cases driven by a controllable `FakeWebSocket`: dispose-inertness, reconnect-cancel, backoff cap/reset, 429 cooldown, single-recovery-on-silence, and keepalive liveness.

## Verification

- `vp check` clean (format, lint, typecheck)
- Full suite green: **950 passed** (8 new), incl. all 47 twitch-chat tests
- Builds clean (shared-utils + twitch-chat)
- Prod stable for 18+ min after the mitigation restart: 0 reconnects, 0 silences, real event delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
