### PR TITLE
fix(twitch-events): stop watcher reconnect stack-overflow crash on Realtime CLOSED

### DIFF
--- a/packages/twitch-events/src/__tests__/sharedMocks.ts
+++ b/packages/twitch-events/src/__tests__/sharedMocks.ts
@@ -53,6 +53,12 @@ export const state: {
   channelCreationCount: number
   // Bumped each time the watcher calls `supabase.removeChannel(...)`.
   removeChannelCount: number
+  // When true, removeChannel() synchronously re-fires the most-recent
+  // subscribe callback with 'CLOSED' — replicating real supabase-js, which
+  // tears the channel down on the same stack and re-emits CLOSED. Off by
+  // default so the other reconnect tests keep their simple semantics; the
+  // re-entrancy regression test flips it on.
+  removeChannelRefiresClosed: boolean
   // If non-empty, sbBuilder.single() on the `accounts` table shifts the next
   // entry off this queue. Lets tests script per-call lookup behavior (e.g.
   // first lookup returns null, second returns a row) and inject transient DB
@@ -98,6 +104,7 @@ export const state: {
   channelSubscribeCallbacks: [],
   channelCreationCount: 0,
   removeChannelCount: 0,
+  removeChannelRefiresClosed: false,
   accountsLookupResults: [],
   usersLookupResults: [],
   streamError: null,
@@ -128,6 +135,7 @@ export function resetState() {
   state.channelSubscribeCallbacks = []
   state.channelCreationCount = 0
   state.removeChannelCount = 0
+  state.removeChannelRefiresClosed = false
   state.accountsLookupResults = []
   state.usersLookupResults = []
   state.streamError = null
@@ -231,6 +239,14 @@ const supabaseMock = {
   },
   removeChannel: (_channel: unknown) => {
     state.removeChannelCount++
+    // Real supabase-js tears the channel down synchronously and re-fires the
+    // status callback with CLOSED on the same stack. Replicate that so the
+    // watcher's reconnect path is exercised against the actual re-entrancy
+    // that crashed prod, not a sanitized no-op.
+    if (state.removeChannelRefiresClosed) {
+      const cb = state.channelSubscribeCallbacks.at(-1)
+      cb?.('CLOSED')
+    }
     return 'ok' as const
   },
 }

--- a/packages/twitch-events/src/__tests__/watcher.test.ts
+++ b/packages/twitch-events/src/__tests__/watcher.test.ts
@@ -280,6 +280,33 @@ describe('setupAccountWatcher', () => {
       expect(state.channelCreationCount).toBe(2)
     })
 
+    it('does not infinitely recurse when removeChannel synchronously re-fires CLOSED', async () => {
+      // Real supabase-js removeChannel() tears the channel down on the same
+      // stack and re-emits CLOSED, re-entering scheduleReconnect. Prod
+      // 2026-06-21: that re-entry sailed past the not-yet-set guard, called
+      // removeChannel again, re-fired CLOSED again, and recursed ~390 deep
+      // until a RangeError (Maximum call stack size exceeded) thrown inside the
+      // winston console transport crashed twitch-events. The guard must be
+      // claimed BEFORE removeChannel so the re-entrant call bails.
+      vi.useFakeTimers()
+      state.removeChannelRefiresClosed = true
+
+      // A single CLOSED — the mock will re-fire CLOSED from inside removeChannel.
+      // With the bug this throws RangeError; fixed, it tears down exactly once.
+      state.channelSubscribeCallbacks[0]('CLOSED')
+
+      expect(state.removeChannelCount).toBe(1)
+      // Exactly one reconnect scheduled, and the warn logged once (not 390×).
+      expect(state.logWarn.filter((l) => l.message.includes('Realtime channel down'))).toHaveLength(
+        1,
+      )
+
+      await vi.advanceTimersByTimeAsync(5100)
+      // One fresh channel from the single scheduled reconnect.
+      expect(state.channelCreationCount).toBe(2)
+      expect(state.channelHandlers.size).toBe(4)
+    })
+
     it('SUBSCRIBED status is logged and does not trigger any reconnect', () => {
       // The initial SUBSCRIBED already fired in beforeEach (synchronous mock).
       expect(state.channelSubscribeStatuses).toContain('SUBSCRIBED')

--- a/packages/twitch-events/src/watcher.ts
+++ b/packages/twitch-events/src/watcher.ts
@@ -38,19 +38,31 @@ export function setupAccountWatcher(): void {
     // Don't pile up reconnect timers if the dead channel's callback fires
     // multiple times for the same outage.
     if (reconnectTimer) return
+    // Claim the guard and detach the dead channel BEFORE touching
+    // removeChannel(). supabase-js tears the channel down synchronously and
+    // re-fires THIS status callback with CLOSED on the same stack — which
+    // re-enters scheduleReconnect. If reconnectTimer / activeChannel were
+    // still unset at that point, the re-entrant call sails past the guard,
+    // calls removeChannel again, re-fires CLOSED again, and recurses until the
+    // stack overflows and the process crashes. (Prod 2026-06-21: one Realtime
+    // blip → ~390-deep recursion → RangeError thrown inside the winston
+    // console transport → twitch-events restart, taking the conduit down and
+    // cascading xhr/conduit-timeout errors into twitch-chat.) Setting state
+    // first makes the re-entrant call hit `if (reconnectTimer) return`.
+    reconnectTimer = setTimeout(subscribe, RECONNECT_DELAY_MS)
+    const deadChannel = activeChannel
+    activeChannel = null
     logger.warn('[WATCHER] Realtime channel down, scheduling reconnect', {
       status,
       err: err?.message,
       delayMs: RECONNECT_DELAY_MS,
     })
-    if (activeChannel) {
+    if (deadChannel) {
       // Tear down the dead channel before re-creating it. supabase-js
       // doesn't auto-clean closed channels and they can leak. removeChannel
       // returns a promise but we don't block reconnect on it.
-      void supabase.removeChannel(activeChannel as Parameters<typeof supabase.removeChannel>[0])
-      activeChannel = null
+      void supabase.removeChannel(deadChannel as Parameters<typeof supabase.removeChannel>[0])
     }
-    reconnectTimer = setTimeout(subscribe, RECONNECT_DELAY_MS)
   }
 
   const subscribe = () => {


### PR DESCRIPTION
## What happened

Prod **2026-06-21 ~02:14Z**: a brief connectivity blip dropped the Supabase Realtime channel in `twitch-events`. Instead of cleanly reconnecting, the watcher recursed ~390 deep and died with `RangeError: Maximum call stack size exceeded` thrown inside the winston console transport (`RestartCount` → 5). The restart briefly dropped the EventSub conduit, cascading `xhr poll error` / `Timeout waiting for conduit data` into `twitch-chat` (~20s) and `Not connected to Dota 2 GC` into `dota`.

Tell-tale signs in the logs: **391** `[WATCHER] Realtime channel down` lines (≈ V8 stack limit ÷ frames-per-level), many at the *identical* millisecond `02:14:27.382Z` — i.e. synchronous self-recursion.

## Root cause

`packages/twitch-events/src/watcher.ts` → `scheduleReconnect()` cleared its guard (`reconnectTimer`) and `activeChannel` **after** calling `supabase.removeChannel()`. But supabase-js tears the channel down **synchronously and re-fires the same status callback with `CLOSED` on the same stack**, re-entering `scheduleReconnect`. With the guard still unset, the re-entrant call sailed past `if (reconnectTimer) return`, called `removeChannel` again, re-fired `CLOSED` again, and recursed until the stack overflowed.

## Fix

Claim `reconnectTimer` and null `activeChannel` **before** `removeChannel()`, so the synchronous re-entrant `CLOSED` hits the guard and bails — exactly one teardown, one scheduled reconnect.

## Tests

The existing reconnect tests passed because the mock's `removeChannel` was a no-op. Added `removeChannelRefiresClosed` to the mock to replicate the real synchronous re-fire, plus a regression test that **reproduces the exact `RangeError` on the old code and passes on the fixed code** (verified red/green). Full suite: 952 passed, check + typecheck clean.

## Deploy note

Single-replica service — deploy is a hard cutover on Coolify (`zwg4g4c`), no rolling overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)