### PR TITLE
fix(dota): report unranked matches in !gm

### DIFF
--- a/packages/dota/src/twitch/commands/gm.ts
+++ b/packages/dota/src/twitch/commands/gm.ts
@@ -1,5 +1,6 @@
 import { t } from 'i18next'
 
+import { LOBBY_TYPE_RANKED } from '../../db/getWL'
 import { MatchDataService } from '../../dota/lib/matchData'
 import { DBSettings } from '../../settings'
 import { gameMedals } from '../../steam/medals'
@@ -29,7 +30,8 @@ commandHandler.registerCommand('gm', {
       return
     }
 
-    const roster = await new MatchDataService(client).resolveRoster()
+    const matchData = new MatchDataService(client)
+    const roster = await matchData.resolveRoster()
     const note = clippingDisabledNote(client, roster.players)
     // No clip/vision data to read at 8500+ with auto-clipping off — the note IS
     // the whole reply; don't prepend the all-"Unknown" medal dump.
@@ -38,16 +40,25 @@ commandHandler.registerCommand('gm', {
       return
     }
 
-    gameMedals(client.locale, message.channel.client.gsi?.map?.matchid, roster.players)
-      .then((desc) => {
-        chatClient.say(message.channel.name, desc, message.user.messageId)
-      })
-      .catch((e) => {
-        chatClient.say(
-          message.channel.name,
-          e?.message ?? t('gameNotFound', { lng: message.channel.client.locale }),
-          message.user.messageId,
-        )
-      })
+    try {
+      const lobbyType = await matchData.getLobbyType().catch(() => null)
+      const desc = await gameMedals(
+        client.locale,
+        message.channel.client.gsi?.map?.matchid,
+        roster.players,
+      )
+      const unrankedNote =
+        lobbyType !== null && lobbyType !== LOBBY_TYPE_RANKED
+          ? ` · ${t('ranked', { context: 'no', lng: client.locale })}`
+          : ''
+
+      chatClient.say(message.channel.name, `${desc}${unrankedNote}`, message.user.messageId)
+    } catch (e) {
+      chatClient.say(
+        message.channel.name,
+        e instanceof Error ? e.message : t('gameNotFound', { lng: message.channel.client.locale }),
+        message.user.messageId,
+      )
+    }
   },
 })

--- a/packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vite-plus/test'
 import { t } from 'i18next'
 import { flushAsync } from '../../../__tests__/sharedMocks.ts'
-import { commandHandler, makeMessage, resetState, state } from './setupMocks.ts'
+import { LOBBY_TYPE_RANKED } from '../../../db/getWL.ts'
+import { commandHandler, liveGsi, makeMessage, resetState, state } from './setupMocks.ts'
 
 // Integration tests that exercise individual chat command handlers via
 // `commandHandler.handleMessage()`. Companion to `CommandHandler.integration.test.ts`
@@ -332,6 +333,36 @@ describe('!avg', () => {
     )
     expect(state.chatSayCalls).toHaveLength(1)
     expect(state.chatSayCalls[0].message).toBe(multiAccount)
+  })
+})
+
+describe('!gm', () => {
+  it('keeps the medals and reports an unranked match', async () => {
+    state.delayedGame = {
+      match: { match_id: '7777777777', lobby_type: 0 },
+    }
+
+    await commandHandler.handleMessage(
+      makeMessage({ content: '!gm', clientOverrides: { gsi: liveGsi() } }),
+    )
+
+    expect(state.chatSayCalls).toHaveLength(1)
+    expect(state.chatSayCalls[0].message).toBe(
+      `${state.gameMedalsResult} · ${t('ranked', { context: 'no', lng: 'en' })}`,
+    )
+  })
+
+  it('keeps the existing medals response for a ranked match', async () => {
+    state.delayedGame = {
+      match: { match_id: '7777777777', lobby_type: LOBBY_TYPE_RANKED },
+    }
+
+    await commandHandler.handleMessage(
+      makeMessage({ content: '!gm', clientOverrides: { gsi: liveGsi() } }),
+    )
+
+    expect(state.chatSayCalls).toHaveLength(1)
+    expect(state.chatSayCalls[0].message).toBe(state.gameMedalsResult)
   })
 })
 

--- a/packages/dota/src/twitch/lib/__tests__/setupMocks.ts
+++ b/packages/dota/src/twitch/lib/__tests__/setupMocks.ts
@@ -76,6 +76,7 @@ export const state: {
   chatSettingsUpdates: Array<{ channelId: string; settings: Record<string, unknown> }>
   // Result returned by the mocked MongoDB `delayedGames` findOne (ranked, spectators, ...).
   delayedGame: Record<string, unknown> | null
+  gameMedalsResult: string
   // Optional override for the mocked `moderateText` — return a custom redacted
   // string. Default passthrough returns the input as-is.
   moderateTextOverride: ((text?: string | string[]) => string | string[] | undefined) | null
@@ -144,6 +145,7 @@ export const state: {
   subscriberOnlyMode: false,
   chatSettingsUpdates: [],
   delayedGame: null,
+  gameMedalsResult: '[Archon 1 avg] Axe: Archon 1',
   moderateTextOverride: null,
   trackDisableReasonCalls: [],
   trackResolveReasonCalls: [],
@@ -183,6 +185,7 @@ export function resetState() {
   state.subscriberOnlyMode = false
   state.chatSettingsUpdates = []
   state.delayedGame = null
+  state.gameMedalsResult = '[Archon 1 avg] Axe: Archon 1'
   state.moderateTextOverride = null
   state.trackDisableReasonCalls = []
   state.trackResolveReasonCalls = []
@@ -417,6 +420,10 @@ function reinstallModuleMocks() {
       }),
       close: async () => undefined,
     },
+  }))
+
+  vi.doMock('../../../steam/medals', () => ({
+    gameMedals: async () => state.gameMedalsResult,
   }))
 }
 


### PR DESCRIPTION
## Linked GH Issues

Closes #302

## Current Behavior

The `!gm` command displays the current game medals without indicating when the match is unranked.

## New Behavior

The command keeps the medal output and appends the localized unranked message used by `!ranked`
when the current match has a known non-ranked lobby type. Ranked matches and matches without lobby
data keep the existing response.

## Testing

- `vp check` for the changed command and test files
- `vp test packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts -t "!gm"`
