### PR TITLE
chore(dota): update dotaconstants for patch-relevant changes

### DIFF
--- a/packages/dota/package.json
+++ b/packages/dota/package.json
@@ -31,7 +31,7 @@
     "cors": "^2.8.5",
     "country-code-emoji": "^2.3.0",
     "deepl-node": "^1.19.1",
-    "dotaconstants": "github:dotabod/dotaconstants#11bc2943c519f379f46d1c41eb86bd9b7a11f8ac",
+    "dotaconstants": "github:dotabod/dotaconstants#e91a90034612f46db34ff3b94d188e66cf83f6bf",
     "express": "^4.21.2",
     "express-body-parser-error-handler": "^1.0.7",
     "franc": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^1.19.1
         version: 1.27.0
       dotaconstants:
-        specifier: github:dotabod/dotaconstants#11bc2943c519f379f46d1c41eb86bd9b7a11f8ac
-        version: https://codeload.github.com/dotabod/dotaconstants/tar.gz/11bc2943c519f379f46d1c41eb86bd9b7a11f8ac
+        specifier: github:dotabod/dotaconstants#e91a90034612f46db34ff3b94d188e66cf83f6bf
+        version: https://codeload.github.com/dotabod/dotaconstants/tar.gz/e91a90034612f46db34ff3b94d188e66cf83f6bf
       express:
         specifier: ^4.21.2
         version: 4.22.2
@@ -1662,9 +1662,9 @@ packages:
     resolution: {gitHosted: true, integrity: sha512-iWo37QWJZXV7nfBKVe1D1OCs10ltkSR67GN2DTVz+PDH0+apWbXajSfEfuK5LYY6sU7U64/LomN+Yer15fo+Jw==, tarball: https://codeload.github.com/dotabod/node-dota2/tar.gz/4a1a09537d5bead430c36427b9a50b770abe56fc}
     version: 7.0.3
 
-  dotaconstants@https://codeload.github.com/dotabod/dotaconstants/tar.gz/11bc2943c519f379f46d1c41eb86bd9b7a11f8ac:
-    resolution: {gitHosted: true, integrity: sha512-33nfGAajthgsbbkIj8Svs+BtA/m6kXkm9xJHzcoZa59o132dIJcFN22QcGGhczIDSz/nS3E/L0cVIpTD5CRglg==, tarball: https://codeload.github.com/dotabod/dotaconstants/tar.gz/11bc2943c519f379f46d1c41eb86bd9b7a11f8ac}
-    version: 10.8.22
+  dotaconstants@https://codeload.github.com/dotabod/dotaconstants/tar.gz/e91a90034612f46db34ff3b94d188e66cf83f6bf:
+    resolution: {gitHosted: true, integrity: sha512-YWstUxL7Zb8BIA4uYGWBBjDmOFkOvH4wddhS9Ngc1Nj/x+Yya5vkckKAt7qZMFdLbfmagpvwVVdiep40EsRD8g==, tarball: https://codeload.github.com/dotabod/dotaconstants/tar.gz/e91a90034612f46db34ff3b94d188e66cf83f6bf}
+    version: 10.8.23
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2553,7 +2553,7 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   steam-resources@https://codeload.github.com/dotabod/node-steam-resources/tar.gz/57ee94899194c3c5a090722632ef3b5df00a3e45:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/dotabod/node-steam-resources/tar.gz/57ee94899194c3c5a090722632ef3b5df00a3e45}
+    resolution: {gitHosted: true, integrity: sha512-bcksZjb/Sa6Q7A5Uh+GWiU5AfoW6u12B1lk7VN+yWNO4AOqpAGK6F0eiEILuS1ngjxHzX57M3IHCahncsLGYig==, tarball: https://codeload.github.com/dotabod/node-steam-resources/tar.gz/57ee94899194c3c5a090722632ef3b5df00a3e45}
     version: 1.2.2
 
   steam-session@1.9.4:
@@ -2581,7 +2581,7 @@ packages:
       - steam-resources
 
   steam@https://codeload.github.com/dotabod/node-steam/tar.gz/e9aa23d43a7a06090a2d96eb4e39aa889c7b8cbb:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/dotabod/node-steam/tar.gz/e9aa23d43a7a06090a2d96eb4e39aa889c7b8cbb}
+    resolution: {gitHosted: true, integrity: sha512-0kny/0AfwRcRv4qghIkpFJ2MVCMC8gjVd/EakCRIIbC5WI9J4nl8N4NTT75HxGW6p/Gf/nxCiFLgUxvH5b2x2Q==, tarball: https://codeload.github.com/dotabod/node-steam/tar.gz/e9aa23d43a7a06090a2d96eb4e39aa889c7b8cbb}
     version: 1.4.1
     engines: {node: '>=4.1.1'}
 
@@ -3991,7 +3991,7 @@ snapshots:
       steam-resources: https://codeload.github.com/dotabod/node-steam-resources/tar.gz/57ee94899194c3c5a090722632ef3b5df00a3e45
       winston: 3.19.0
 
-  dotaconstants@https://codeload.github.com/dotabod/dotaconstants/tar.gz/11bc2943c519f379f46d1c41eb86bd9b7a11f8ac: {}
+  dotaconstants@https://codeload.github.com/dotabod/dotaconstants/tar.gz/e91a90034612f46db34ff3b94d188e66cf83f6bf: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
Automated dotaconstants refresh.

This PR is created only when patch-relevant datasets changed in `dotabod/dotaconstants`:
- `build/heroes.json`
- `build/items.json`
- `build/item_ids.json`
- `build/abilities.json`
- `build/hero_abilities.json`
- `build/aghs_desc.json`

Updated:
- `packages/dota/package.json`
- `pnpm-lock.yaml`

Comparison:
- Previous SHA: `11bc2943c519f379f46d1c41eb86bd9b7a11f8ac`
- Latest SHA: `e91a90034612f46db34ff3b94d188e66cf83f6bf`
- Changed relevant files: `build/aghs_desc.json`