### PR TITLE
Stop diagnostic heartbeats from refreshing overlays

### DIFF
--- a/packages/dota/src/db/__tests__/watcher-mocks.ts
+++ b/packages/dota/src/db/__tests__/watcher-mocks.ts
@@ -18,7 +18,6 @@ type ChannelHandler = (payload: {
   old?: Record<string, unknown>
   eventType?: string
 }) => unknown
-type WatcherSocketPayload = string | Record<string, unknown>
 
 export const watcherState: {
   channelHandlers: Map<string, ChannelHandler>
@@ -36,7 +35,7 @@ export const watcherState: {
   // gsiHandlers is enough; this state is just for assertion convenience.
   loggerInfoCalls: { message: string; meta: Record<string, unknown> }[]
   loggerErrorCalls: { message: string; meta: Record<string, unknown> }[]
-  socketEmits: { event: string; payload: WatcherSocketPayload; room: string }[]
+  socketEmits: { event: string; payload: string; room: string }[]
 } = {
   channelCreationCount: 0,
   channelHandlers: new Map(),
@@ -219,7 +218,7 @@ vi.doMock('../../dota/server', () => ({
   server: {
     io: {
       to: (room: string) => ({
-        emit: (event: string, payload: WatcherSocketPayload) => {
+        emit: (event: string, payload: string) => {
           watcherState.socketEmits.push({ event, payload, room })
         },
       }),

--- a/packages/dota/src/db/__tests__/watcher-mocks.ts
+++ b/packages/dota/src/db/__tests__/watcher-mocks.ts
@@ -35,6 +35,7 @@ export const watcherState: {
   // gsiHandlers is enough; this state is just for assertion convenience.
   loggerInfoCalls: { message: string; meta: Record<string, unknown> }[]
   loggerErrorCalls: { message: string; meta: Record<string, unknown> }[]
+  socketEmits: { event: string; payload: unknown; room: string }[]
 } = {
   channelCreationCount: 0,
   channelHandlers: new Map(),
@@ -42,6 +43,7 @@ export const watcherState: {
   clearCacheCalls: [],
   loggerErrorCalls: [],
   loggerInfoCalls: [],
+  socketEmits: [],
   toggleDotabodCalls: [],
 }
 
@@ -53,6 +55,7 @@ export const resetWatcherState = function resetWatcherState() {
   watcherState.toggleDotabodCalls = []
   watcherState.loggerInfoCalls = []
   watcherState.loggerErrorCalls = []
+  watcherState.socketEmits = []
 }
 
 // Chainable supabase mock. Only the subscriptions table (queried via
@@ -212,7 +215,15 @@ vi.doMock('../../dota/lib/ranks', () => ({
 }))
 
 vi.doMock('../../dota/server', () => ({
-  server: { io: { to: () => ({ emit: () => {} }) } },
+  server: {
+    io: {
+      to: (room: string) => ({
+        emit: (event: string, payload: unknown) => {
+          watcherState.socketEmits.push({ event, payload, room })
+        },
+      }),
+    },
+  },
 }))
 
 await initTestI18n()

--- a/packages/dota/src/db/__tests__/watcher-mocks.ts
+++ b/packages/dota/src/db/__tests__/watcher-mocks.ts
@@ -18,6 +18,7 @@ type ChannelHandler = (payload: {
   old?: Record<string, unknown>
   eventType?: string
 }) => unknown
+type WatcherSocketPayload = string | Record<string, unknown>
 
 export const watcherState: {
   channelHandlers: Map<string, ChannelHandler>
@@ -35,7 +36,7 @@ export const watcherState: {
   // gsiHandlers is enough; this state is just for assertion convenience.
   loggerInfoCalls: { message: string; meta: Record<string, unknown> }[]
   loggerErrorCalls: { message: string; meta: Record<string, unknown> }[]
-  socketEmits: { event: string; payload: unknown; room: string }[]
+  socketEmits: { event: string; payload: WatcherSocketPayload; room: string }[]
 } = {
   channelCreationCount: 0,
   channelHandlers: new Map(),
@@ -218,7 +219,7 @@ vi.doMock('../../dota/server', () => ({
   server: {
     io: {
       to: (room: string) => ({
-        emit: (event: string, payload: unknown) => {
+        emit: (event: string, payload: WatcherSocketPayload) => {
           watcherState.socketEmits.push({ event, payload, room })
         },
       }),

--- a/packages/dota/src/db/__tests__/watcher.test.ts
+++ b/packages/dota/src/db/__tests__/watcher.test.ts
@@ -11,6 +11,7 @@
 // silently re-deleted) shipped to prod. See watcher.ts and clearCacheForUser.ts.
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { SETUP_SIGNAL_KEYS } from '../../dota/setup-signal-keys'
 import {
   fire,
   gsiHandlers,
@@ -236,6 +237,19 @@ describe('dota watcher: DELETE:users', () => {
 })
 
 describe('dota watcher: settings', () => {
+  it.each(Object.values(SETUP_SIGNAL_KEYS))(
+    'does not refresh overlays for setup signal updates: %s',
+    async (key) => {
+      seedClient({ userId: 'u-setup-signal' })
+
+      await fire('*', 'settings', {
+        new: { key, userId: 'u-setup-signal', value: true },
+      })
+
+      expect(watcherState.socketEmits).toHaveLength(0)
+    }
+  )
+
   it('keeps high-frequency activity updates out of info logs', async () => {
     seedClient({ userId: 'u-heartbeat' })
 
@@ -257,6 +271,11 @@ describe('dota watcher: settings', () => {
 
     expect(client.settings).toContainEqual({ key: 'wlStatsDays', value: 30 })
     expect(handler.emitWLUpdate).toHaveBeenCalledOnce()
+    expect(watcherState.socketEmits).toContainEqual({
+      event: 'refresh-settings',
+      payload: 'wlStatsDays',
+      room: 'u-wl',
+    })
   })
 
   it('recomputes the overlay when the WL challenge start date changes', async () => {

--- a/packages/dota/src/db/watcher.ts
+++ b/packages/dota/src/db/watcher.ts
@@ -7,6 +7,7 @@ import findUser from '../dota/lib/connected-streamers'
 import { gsiHandlers, invalidTokens, twitchIdToToken, twitchNameToToken } from '../dota/lib/consts'
 import { getRankDetail } from '../dota/lib/ranks'
 import { server } from '../dota/server'
+import { SETUP_SIGNAL_KEYS } from '../dota/setup-signal-keys'
 import { DBSettings } from '../settings'
 import { twitchChat } from '../steam/ws'
 import { chatClient } from '../twitch/chat-client'
@@ -15,6 +16,8 @@ import { isSubscriptionActive } from '../types/subscription'
 import getDBUser from './get-db-user'
 import { handleUserOnlineMessages } from './handle-scheduled-messages'
 import { handleStreamStatusTransition } from './handle-stream-status-transition'
+
+const setupSignalKeys = new Set<string>(Object.values(SETUP_SIGNAL_KEYS))
 
 const isNonEmptyString = function isNonEmptyString(
   value: string | null | undefined
@@ -514,6 +517,9 @@ class SetupSupabase {
         (payload: { new: Partial<Tables<'settings'>> }) => {
           const newObj = payload.new
           if (!isNonEmptyString(newObj.userId) || !isNonEmptyString(newObj.key)) {
+            return
+          }
+          if (setupSignalKeys.has(newObj.key)) {
             return
           }
           const client = findUser(newObj.userId)

--- a/packages/dota/src/dota/__tests__/gsi-server-connection.test.ts
+++ b/packages/dota/src/dota/__tests__/gsi-server-connection.test.ts
@@ -11,6 +11,8 @@ import type { GSIHandlerType } from '../gsi-handler-types'
 
 type ServerConnectionHandler = Parameters<Server['on']>[1]
 type SocketEventHandler = Parameters<Socket['on']>[1]
+type DiagnosticBroadcast = (event: 'diagnostic-overlay-probe') => void
+type DiagnosticRoomTarget = (room: string) => { emit: DiagnosticBroadcast }
 interface MiddlewareSocket {
   data: {
     clientType?: string
@@ -142,14 +144,14 @@ describe('overlay socket connection state', () => {
 
   it('does not count a dashboard diagnostic socket as an OBS overlay', async () => {
     new GSIServer()
-    const broadcastEmit = vi.fn()
+    const broadcastEmit = vi.fn<DiagnosticBroadcast>()
     const socket = {
       data: { clientType: 'setup-diagnostic', dotabodClient: { token: 'diagnostic-token' } },
       emit: vi.fn(),
       handshake: { auth: { client: 'setup-diagnostic', token: 'diagnostic-token' } },
       join: vi.fn(),
       on: vi.fn(),
-      to: vi.fn(() => ({ emit: broadcastEmit })),
+      to: vi.fn<DiagnosticRoomTarget>().mockImplementation(() => ({ emit: broadcastEmit })),
     }
 
     await socketState.handlers.get('connection')?.(socket)

--- a/packages/dota/src/dota/__tests__/gsi-server-connection.test.ts
+++ b/packages/dota/src/dota/__tests__/gsi-server-connection.test.ts
@@ -142,18 +142,22 @@ describe('overlay socket connection state', () => {
 
   it('does not count a dashboard diagnostic socket as an OBS overlay', async () => {
     new GSIServer()
+    const broadcastEmit = vi.fn()
     const socket = {
       data: { clientType: 'setup-diagnostic', dotabodClient: { token: 'diagnostic-token' } },
       emit: vi.fn(),
       handshake: { auth: { client: 'setup-diagnostic', token: 'diagnostic-token' } },
       join: vi.fn(),
       on: vi.fn(),
+      to: vi.fn(() => ({ emit: broadcastEmit })),
     }
 
     await socketState.handlers.get('connection')?.(socket)
 
     expect(recordOverlaySocketActivity).not.toHaveBeenCalled()
     expect(socket.join).not.toHaveBeenCalled()
+    expect(socket.to).toHaveBeenCalledWith('diagnostic-token')
+    expect(broadcastEmit).toHaveBeenCalledWith('diagnostic-overlay-probe')
     expect(socket.emit).toHaveBeenCalledWith('diagnostic-ready', { status: 'ok' })
   })
 

--- a/packages/dota/src/dota/__tests__/gsi-server-connection.test.ts
+++ b/packages/dota/src/dota/__tests__/gsi-server-connection.test.ts
@@ -151,7 +151,7 @@ describe('overlay socket connection state', () => {
       handshake: { auth: { client: 'setup-diagnostic', token: 'diagnostic-token' } },
       join: vi.fn(),
       on: vi.fn(),
-      to: vi.fn<DiagnosticRoomTarget>().mockImplementation(() => ({ emit: broadcastEmit })),
+      to: vi.fn<DiagnosticRoomTarget>().mockReturnValue({ emit: broadcastEmit }),
     }
 
     await socketState.handlers.get('connection')?.(socket)

--- a/packages/dota/src/dota/gsi-server.ts
+++ b/packages/dota/src/dota/gsi-server.ts
@@ -447,6 +447,7 @@ const handleSocketConnection = async function handleSocketConnection(socket: Gsi
   const { clientType, dotabodClient } = socket.data ?? {}
   const client = dotabodClient ?? gsiHandlers.get(token)?.client
   if (clientType === 'setup-diagnostic') {
+    socket.to(token).emit('diagnostic-overlay-probe')
     socket.emit('diagnostic-ready', { status: 'ok' })
     return
   }

--- a/packages/dota/src/dota/setup-signal-keys.ts
+++ b/packages/dota/src/dota/setup-signal-keys.ts
@@ -5,6 +5,7 @@ export const SETUP_SIGNAL_KEYS = {
   gsi: 'gsi_first_seen_at',
   gsiLastSeen: 'gsi_last_seen_at',
   overlay: 'overlay_first_seen_at',
+  overlayPageLastSeen: 'overlay_page_last_seen_at',
   overlaySocketLastSeen: 'overlay_socket_last_seen_at',
 } as const
 


### PR DESCRIPTION
## Summary

- ignore setup and diagnostic setting changes in the realtime watcher so they cannot emit refresh-settings
- request an on-demand presence beacon from connected OBS overlays when dashboard diagnostics runs
- keep the dashboard diagnostic socket out of OBS activity tracking

## Companion change

Frontend: https://github.com/dotabod/frontend/pull/274