### PR TITLE
Fix/items invalid hero help

### DIFF
--- a/packages/dota/src/twitch/commands/items.ts
+++ b/packages/dota/src/twitch/commands/items.ts
@@ -2,7 +2,7 @@ import DOTA_ITEM_IDS from 'dotaconstants/build/item_ids.json' with { type: 'json
 import DOTA_ITEMS from 'dotaconstants/build/items.json' with { type: 'json' }
 import { t } from 'i18next'
 
-import { getHeroById, getHeroNameOrColor } from '../../dota/lib/heroes'
+import { getHeroNameOrColor } from '../../dota/lib/heroes'
 import { isSpectator } from '../../dota/lib/is-spectator'
 import { DBSettings } from '../../settings'
 import { findRealtimePlayer, getRealtimeStats } from '../../steam/realtime-stats'
@@ -60,10 +60,6 @@ const getItems = async function getItems({
     command,
     locale,
   })
-
-  if (args.length > 0 && getHeroById(hero?.id) === null) {
-    throw new CustomError(t('invalidHero', { command, heroList: '', lng: locale }))
-  }
 
   let itemList: string[]
   if (isSpectator(packet)) {

--- a/packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/commands.integration.test.ts
@@ -270,9 +270,8 @@ describe('!gpm', () => {
   it('reports lookup errors for an unknown hero argument', async () => {
     await commandHandler.handleMessage(makeMessage({ content: '!gpm unknown-hero' }))
     expect(state.chatSayCalls).toHaveLength(1)
-    expect(state.chatSayCalls[0].message).toBe(
-      t('missingMatchData', { emote: 'PauseChamp', lng: 'en' })
-    )
+    expect(state.chatSayCalls[0].message).toContain('Invalid command')
+    expect(state.chatSayCalls[0].message).toContain('!gpm')
   })
 })
 

--- a/packages/dota/src/twitch/lib/__tests__/match-stats-commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/match-stats-commands.integration.test.ts
@@ -48,11 +48,10 @@ describe('!items', () => {
     )
 
     expect(state.chatSayCalls).toHaveLength(1)
-    const { message } = state.chatSayCalls[0]
-    expect(message).toContain('Invalid hero specified')
-    expect(message).toContain('Axe')
-    expect(message).toContain('Anti-Mage')
-    expect(message.trimEnd().endsWith('from')).toBeFalsy()
+    expect(state.chatSayCalls[0].message).toContain('Invalid hero specified')
+    expect(state.chatSayCalls[0].message).toContain('Axe')
+    expect(state.chatSayCalls[0].message).toContain('Anti-Mage')
+    expect(state.chatSayCalls[0].message.trimEnd().endsWith('from')).toBeFalsy()
   })
 
   it('rejects a globally valid hero that is not in the current match', async () => {
@@ -69,11 +68,10 @@ describe('!items', () => {
     )
 
     expect(state.chatSayCalls).toHaveLength(1)
-    const { message } = state.chatSayCalls[0]
-    expect(message).toContain('Invalid hero specified')
-    expect(message).toContain('Axe')
-    expect(message).toContain('Anti-Mage')
-    expect(message.trimEnd().endsWith('from')).toBeFalsy()
+    expect(state.chatSayCalls[0].message).toContain('Invalid hero specified')
+    expect(state.chatSayCalls[0].message).toContain('Axe')
+    expect(state.chatSayCalls[0].message).toContain('Anti-Mage')
+    expect(state.chatSayCalls[0].message.trimEnd().endsWith('from')).toBeFalsy()
   })
 
   it('reports gameNotFound for a non-numeric match id', async () => {

--- a/packages/dota/src/twitch/lib/__tests__/match-stats-commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/match-stats-commands.integration.test.ts
@@ -48,11 +48,11 @@ describe('!items', () => {
     )
 
     expect(state.chatSayCalls).toHaveLength(1)
-    const message = state.chatSayCalls[0].message
+    const { message } = state.chatSayCalls[0]
     expect(message).toContain('Invalid hero specified')
     expect(message).toContain('Axe')
     expect(message).toContain('Anti-Mage')
-    expect(message.trimEnd().endsWith('from')).toBe(false)
+    expect(message.trimEnd().endsWith('from')).toBeFalsy()
   })
 
   it('rejects a globally valid hero that is not in the current match', async () => {
@@ -69,11 +69,11 @@ describe('!items', () => {
     )
 
     expect(state.chatSayCalls).toHaveLength(1)
-    const message = state.chatSayCalls[0].message
+    const { message } = state.chatSayCalls[0]
     expect(message).toContain('Invalid hero specified')
     expect(message).toContain('Axe')
     expect(message).toContain('Anti-Mage')
-    expect(message.trimEnd().endsWith('from')).toBe(false)
+    expect(message.trimEnd().endsWith('from')).toBeFalsy()
   })
 
   it('reports gameNotFound for a non-numeric match id', async () => {

--- a/packages/dota/src/twitch/lib/__tests__/match-stats-commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/match-stats-commands.integration.test.ts
@@ -34,13 +34,46 @@ describe('!items', () => {
     expect(state.chatSayCalls[0].message).toBe(notPlaying)
   })
 
-  it('rejects an unknown hero argument instead of returning the streamer items', async () => {
+  it('rejects an unknown hero argument with the active match hero list', async () => {
+    state.delayedGame = {
+      match: { match_id: '7777777777', server_steam_id: '90292108836096020' },
+      players: [
+        { accountid: 111, heroid: 2 },
+        { accountid: 99_999, heroid: 1 },
+      ],
+    }
+
     await commandHandler.handleMessage(
       makeMessage({ clientOverrides: { gsi: liveGsi() }, content: '!item distiller' })
     )
 
     expect(state.chatSayCalls).toHaveLength(1)
-    expect(state.chatSayCalls[0].message).toContain('Invalid hero specified')
+    const message = state.chatSayCalls[0].message
+    expect(message).toContain('Invalid hero specified')
+    expect(message).toContain('Axe')
+    expect(message).toContain('Anti-Mage')
+    expect(message.trimEnd().endsWith('from')).toBe(false)
+  })
+
+  it('rejects a globally valid hero that is not in the current match', async () => {
+    state.delayedGame = {
+      match: { match_id: '7777777777', server_steam_id: '90292108836096020' },
+      players: [
+        { accountid: 111, heroid: 2 },
+        { accountid: 99_999, heroid: 1 },
+      ],
+    }
+
+    await commandHandler.handleMessage(
+      makeMessage({ clientOverrides: { gsi: liveGsi() }, content: '!items pudge' })
+    )
+
+    expect(state.chatSayCalls).toHaveLength(1)
+    const message = state.chatSayCalls[0].message
+    expect(message).toContain('Invalid hero specified')
+    expect(message).toContain('Axe')
+    expect(message).toContain('Anti-Mage')
+    expect(message.trimEnd().endsWith('from')).toBe(false)
   })
 
   it('reports gameNotFound for a non-numeric match id', async () => {

--- a/packages/dota/src/twitch/lib/__tests__/profile-commands.integration.test.ts
+++ b/packages/dota/src/twitch/lib/__tests__/profile-commands.integration.test.ts
@@ -36,7 +36,7 @@ describe('!opendota', () => {
     await commandHandler.handleMessage(
       makeMessage({
         clientOverrides: { gsi: liveGsi() },
-        content: '!opendota me',
+        content: '!opendota antimage',
       })
     )
     expect(state.chatSayCalls).toHaveLength(1)

--- a/packages/dota/src/twitch/lib/get-player-from-args.ts
+++ b/packages/dota/src/twitch/lib/get-player-from-args.ts
@@ -104,11 +104,15 @@ export const getPlayerFromArgs = async function getPlayerFromArgs({
   const hero = getHeroByName(args.join('').toLowerCase().trim(), heroIdsInMatch)
   const playerIdx = resolvePlayerIndex({ firstArg, hero, packet, players })
 
+  if (playerIdx < 0) {
+    throw new CustomError(t('invalidHero', { command, heroList, lng: locale }))
+  }
+
   // Translate the matched RosterPlayer back to the GSI-style snake_case shape the 15+ callers
   // (hero, dotabuff, opendota, profile, stats, items, aghs, d2pt, gpm, innate, shard, xpm, apm)
   // expect via `player.accountid` / `player.heroid`. This is the one boundary point where the
   // internal RosterPlayer shape meets external GSI-shaped data.
-  const matched = players[playerIdx ?? -1]
+  const matched = players[playerIdx]
   const matchedLegacy = toLegacyPlayer(matched)
   const defaultPlayer = {
     accountid: Number(packet?.player?.accountid),

--- a/packages/dota/src/twitch/lib/get-player-from-args.ts
+++ b/packages/dota/src/twitch/lib/get-player-from-args.ts
@@ -105,7 +105,12 @@ export const getPlayerFromArgs = async function getPlayerFromArgs({
   const playerIdx = resolvePlayerIndex({ firstArg, hero, packet, players })
 
   if (playerIdx < 0) {
-    throw new CustomError(t('invalidHero', { command, heroList, lng: locale }))
+    if (heroList.length > 0) {
+      throw new CustomError(t('invalidHero', { command, heroList, lng: locale }))
+    }
+    throw new CustomError(
+      t('invalidColorNew', { colorList: heroColors.join(' · '), command, lng: locale })
+    )
   }
 
   // Translate the matched RosterPlayer back to the GSI-style snake_case shape the 15+ callers


### PR DESCRIPTION
Reject unmatched hero/slot/color args in getPlayerFromArgs with the
current roster list so chat no longer ends in a blank "from".

Co-authored-by: Cursor <cursoragent@cursor.com># Pull Request Title

## Linked GH Issues

## Current Behavior

## New Behavior
